### PR TITLE
Forbid pressing 'end turn' during enemy's turn

### DIFF
--- a/src/screen/game.rs
+++ b/src/screen/game.rs
@@ -177,6 +177,9 @@ impl Game {
     }
 
     fn end_turn(&mut self, context: &mut Context) {
+        if self.block_timer.is_some() {
+            return;
+        }
         self.deselect(context);
         let command = command::Command::EndTurn(command::EndTurn);
         let mut actions = Vec::new();


### PR DESCRIPTION
FIxes #139 