### PR TITLE
Migrate to `std::time::Duration`

### DIFF
--- a/hate/examples/actions.rs
+++ b/hate/examples/actions.rs
@@ -1,8 +1,9 @@
 extern crate cgmath;
 extern crate hate;
 
+use std::time::Duration;
 use cgmath::vec2;
-use hate::{Context, Event, Scene, Screen, Time};
+use hate::{Context, Event, Scene, Screen};
 use hate::geom::Point;
 use hate::scene::Layer;
 use hate::scene::action;
@@ -41,7 +42,7 @@ impl ActionsScreen {
         let delta = Point(vec2(0.0, 2.0));
         let action = Box::new(action::Sequence::new(vec![
             Box::new(action::Show::new(&self.layers.fg, &sprite)),
-            Box::new(action::MoveBy::new(&sprite, delta, Time(2.0))),
+            Box::new(action::MoveBy::new(&sprite, delta, Duration::from_millis(2_000))),
             Box::new(action::Hide::new(&self.layers.fg, &sprite)),
         ]));
         self.scene.add_action(action);
@@ -54,9 +55,9 @@ impl ActionsScreen {
         sprite.set_color(invisible);
         let action = Box::new(action::Sequence::new(vec![
             Box::new(action::Show::new(&self.layers.fg, &sprite)),
-            Box::new(action::ChangeColorTo::new(&sprite, visible, Time(0.3))),
-            Box::new(action::Sleep::new(Time(1.0))),
-            Box::new(action::ChangeColorTo::new(&sprite, invisible, Time(1.0))),
+            Box::new(action::ChangeColorTo::new(&sprite, visible, Duration::from_millis(300))),
+            Box::new(action::Sleep::new(Duration::from_millis(1_000))),
+            Box::new(action::ChangeColorTo::new(&sprite, invisible, Duration::from_millis(1_000))),
             Box::new(action::Hide::new(&self.layers.fg, &sprite)),
         ]));
         self.scene.add_action(action);
@@ -64,7 +65,7 @@ impl ActionsScreen {
 }
 
 impl Screen for ActionsScreen {
-    fn tick(&mut self, context: &mut Context, dtime: Time) {
+    fn tick(&mut self, context: &mut Context, dtime: Duration) {
         self.scene.tick(dtime);
         self.scene.draw(context);
     }

--- a/hate/examples/empty_screen.rs
+++ b/hate/examples/empty_screen.rs
@@ -1,11 +1,12 @@
 extern crate hate;
 
+use std::time::Duration;
+use hate::{Context, Event, Screen};
+
 pub struct EmptyScreen;
 
-use hate::{Context, Event, Screen, Time};
-
 impl Screen for EmptyScreen {
-    fn tick(&mut self, _: &mut Context, _: Time) {}
+    fn tick(&mut self, _: &mut Context, _: Duration) {}
 
     fn handle_event(&mut self, _: &mut Context, _: Event) {}
 }

--- a/hate/examples/gui.rs
+++ b/hate/examples/gui.rs
@@ -1,6 +1,7 @@
 extern crate hate;
 
-use hate::{Context, Event, Screen, Sprite, Time};
+use std::time::Duration;
+use hate::{Context, Event, Screen, Sprite};
 use hate::geom::Point;
 use hate::gui::{self, Gui};
 
@@ -163,7 +164,7 @@ impl GuiTest {
 }
 
 impl Screen for GuiTest {
-    fn tick(&mut self, context: &mut Context, _: Time) {
+    fn tick(&mut self, context: &mut Context, _: Duration) {
         self.gui.draw(context);
     }
 

--- a/hate/src/context.rs
+++ b/hate/src/context.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::sync::mpsc::Sender;
 use std::path::{Path, PathBuf};
-use std::time;
 use cgmath::{self, InnerSpace, Matrix4, SquareMatrix, Vector2, Zero};
 use glutin::{self, Api, GlContext, MouseButton};
 use glutin::ElementState::{Pressed, Released};
@@ -12,7 +11,6 @@ use gfx;
 use gfx_device_gl;
 use gfx_window_glutin;
 use settings::Settings;
-use time::Time;
 use event::Event;
 use screen;
 use fs;
@@ -165,7 +163,6 @@ pub struct Context {
     pso: gfx::PipelineState<gfx_device_gl::Resources, pipe::Meta>,
     factory: gfx_device_gl::Factory,
     font: rusttype::Font<'static>,
-    start_time: time::Instant,
     events: Vec<Event>,
     settings: Settings,
     texture_cache: HashMap<PathBuf, Texture>,
@@ -216,7 +213,6 @@ impl Context {
             commands_tx: tx,
             font,
             mouse: MouseState::default(),
-            start_time: time::Instant::now(),
             events: Vec::new(),
             texture_cache: HashMap::new(),
             text_texture_cache: HashMap::new(),
@@ -254,10 +250,6 @@ impl Context {
     pub(crate) fn clear(&mut self) {
         self.encoder.clear(&self.data.out, self.clear_color);
         self.encoder.clear_depth(&self.data.out_depth, 1.0);
-    }
-
-    pub fn now(&self) -> Time {
-        Time::from_duration(time::Instant::now() - self.start_time)
     }
 
     pub(crate) fn should_close(&self) -> bool {

--- a/hate/src/lib.rs
+++ b/hate/src/lib.rs
@@ -41,6 +41,5 @@ pub use visualizer::Visualizer;
 pub use sprite::Sprite;
 pub use screen::Screen;
 pub use context::Context;
-pub use time::Time;
 pub use event::Event;
 pub use scene::Scene;

--- a/hate/src/scene/action/change_color_to.rs
+++ b/hate/src/scene/action/change_color_to.rs
@@ -1,4 +1,5 @@
-use time::Time;
+use std::time::Duration;
+use time;
 use sprite::Sprite;
 use scene::Action;
 
@@ -7,24 +8,24 @@ pub struct ChangeColorTo {
     sprite: Sprite,
     from: [f32; 4],
     to: [f32; 4],
-    duration: Time,
-    progress: Time,
+    duration: Duration,
+    progress: Duration,
 }
 
 impl ChangeColorTo {
-    pub fn new(sprite: &Sprite, to: [f32; 4], duration: Time) -> Self {
+    pub fn new(sprite: &Sprite, to: [f32; 4], duration: Duration) -> Self {
         Self {
             sprite: sprite.clone(),
             from: sprite.color(),
             to,
             duration,
-            progress: Time(0.0),
+            progress: Duration::new(0, 0),
         }
     }
 }
 
 impl Action for ChangeColorTo {
-    fn duration(&self) -> Time {
+    fn duration(&self) -> Duration {
         self.duration
     }
 
@@ -36,22 +37,23 @@ impl Action for ChangeColorTo {
         self.sprite.set_color(self.to);
     }
 
-    fn update(&mut self, mut dtime: Time) {
-        if dtime.0 + self.progress.0 > self.duration.0 {
-            dtime = Time(self.duration.0 - self.progress.0);
+    fn update(&mut self, mut dtime: Duration) {
+        if dtime + self.progress > self.duration {
+            dtime = self.duration - self.progress;
         }
-        let k = self.progress.0 / self.duration.0;
+        let progress_f = time::duration_to_f32(self.progress);
+        let duration_f = time::duration_to_f32(self.duration);
+        let k = progress_f / duration_f;
         let mut color = [0.0; 4];
         for (i, color_i) in color.iter_mut().enumerate().take(4) {
             let diff = self.to[i] - self.from[i];
             *color_i = self.from[i] + diff * k;
         }
         self.sprite.set_color(color);
-        self.progress.0 += dtime.0;
+        self.progress += dtime;
     }
 
     fn is_finished(&self) -> bool {
-        let eps = 0.00001;
-        self.progress.0 > (self.duration.0 - eps)
+        self.progress >= self.duration
     }
 }

--- a/hate/src/scene/action/mod.rs
+++ b/hate/src/scene/action/mod.rs
@@ -1,5 +1,5 @@
+use std::time::Duration;
 use std::fmt::Debug;
-use time::Time;
 
 pub use scene::action::sequence::Sequence;
 pub use scene::action::show::Show;
@@ -25,11 +25,11 @@ mod change_color_to;
 
 pub trait Action: Debug {
     fn begin(&mut self) {}
-    fn update(&mut self, _dtime: Time) {}
+    fn update(&mut self, _dtime: Duration) {}
     fn end(&mut self) {}
 
-    fn duration(&self) -> Time {
-        Time(0.0)
+    fn duration(&self) -> Duration {
+        Duration::new(0, 0)
     }
 
     fn try_fork(&mut self) -> Option<Box<Action>> {

--- a/hate/src/scene/action/move_by.rs
+++ b/hate/src/scene/action/move_by.rs
@@ -1,4 +1,5 @@
-use time::Time;
+use std::time::Duration;
+use time;
 use sprite::Sprite;
 use scene::Action;
 use geom::Point;
@@ -6,39 +7,40 @@ use geom::Point;
 #[derive(Debug)]
 pub struct MoveBy {
     sprite: Sprite,
-    duration: Time,
+    duration: Duration,
     delta: Point,
-    progress: Time,
+    progress: Duration,
 }
 
 impl MoveBy {
-    pub fn new(sprite: &Sprite, delta: Point, duration: Time) -> Self {
+    pub fn new(sprite: &Sprite, delta: Point, duration: Duration) -> Self {
         Self {
             sprite: sprite.clone(),
             delta,
             duration,
-            progress: Time(0.0),
+            progress: Duration::new(0, 0),
         }
     }
 }
 
 impl Action for MoveBy {
-    fn duration(&self) -> Time {
+    fn duration(&self) -> Duration {
         self.duration
     }
 
-    fn update(&mut self, mut dtime: Time) {
+    fn update(&mut self, mut dtime: Duration) {
         let old_pos = self.sprite.pos();
-        if dtime.0 + self.progress.0 > self.duration.0 {
-            dtime = Time(self.duration.0 - self.progress.0);
+        if dtime + self.progress > self.duration {
+            dtime = self.duration - self.progress;
         }
-        let new_pos = Point(old_pos.0 + dtime.0 * self.delta.0 / self.duration.0);
+        let dtime_f = time::duration_to_f32(dtime);
+        let duration_f = time::duration_to_f32(self.duration);
+        let new_pos = Point(old_pos.0 + dtime_f * self.delta.0 / duration_f);
         self.sprite.set_pos(new_pos);
-        self.progress.0 += dtime.0;
+        self.progress += dtime;
     }
 
     fn is_finished(&self) -> bool {
-        let eps = 0.00001;
-        self.progress.0 > (self.duration.0 - eps)
+        self.progress >= self.duration
     }
 }

--- a/hate/src/scene/action/sequence.rs
+++ b/hate/src/scene/action/sequence.rs
@@ -1,18 +1,18 @@
 use std::collections::VecDeque;
-use time::Time;
+use std::time::Duration;
 use scene::Action;
 
 #[derive(Debug)]
 pub struct Sequence {
     actions: VecDeque<Box<Action>>,
-    duration: Time,
+    duration: Duration,
 }
 
 impl Sequence {
     pub fn new(actions: Vec<Box<Action>>) -> Self {
-        let mut total_time = Time(0.0);
+        let mut total_time = Duration::new(0, 0);
         for action in &actions {
-            total_time.0 += action.duration().0;
+            total_time += action.duration();
         }
         Self {
             actions: actions.into(),
@@ -37,7 +37,7 @@ impl Sequence {
 }
 
 impl Action for Sequence {
-    fn duration(&self) -> Time {
+    fn duration(&self) -> Duration {
         self.duration
     }
 
@@ -47,7 +47,7 @@ impl Action for Sequence {
         }
     }
 
-    fn update(&mut self, dtime: Time) {
+    fn update(&mut self, dtime: Duration) {
         if self.actions.is_empty() {
             return;
         }

--- a/hate/src/scene/action/sleep.rs
+++ b/hate/src/scene/action/sleep.rs
@@ -1,31 +1,31 @@
-use time::Time;
+use std::time::Duration;
 use scene::Action;
 
 #[derive(Debug)]
 pub struct Sleep {
-    duration: Time,
-    time: Time,
+    duration: Duration,
+    time: Duration,
 }
 
 impl Sleep {
-    pub fn new(duration: Time) -> Self {
+    pub fn new(duration: Duration) -> Self {
         Self {
-            duration: duration,
-            time: Time(0.0),
+            duration,
+            time: Duration::new(0, 0),
         }
     }
 }
 
 impl Action for Sleep {
-    fn duration(&self) -> Time {
+    fn duration(&self) -> Duration {
         self.duration
     }
 
     fn is_finished(&self) -> bool {
-        self.time.0 / self.duration.0 > 1.0
+        self.duration < self.time
     }
 
-    fn update(&mut self, dtime: Time) {
-        self.time.0 += dtime.0;
+    fn update(&mut self, dtime: Duration) {
+        self.time += dtime;
     }
 }

--- a/hate/src/scene/mod.rs
+++ b/hate/src/scene/mod.rs
@@ -1,8 +1,8 @@
 use std::rc::Rc;
 use std::cell::RefCell;
+use std::time::Duration;
 use sprite::Sprite;
 use context::Context;
-use time::Time;
 
 pub use scene::action::Action;
 
@@ -71,7 +71,7 @@ impl Scene {
         self.interpreter.add(action);
     }
 
-    pub fn tick(&mut self, dtime: Time) {
+    pub fn tick(&mut self, dtime: Duration) {
         self.interpreter.tick(dtime);
     }
 }
@@ -93,7 +93,7 @@ impl ActionInterpreter {
         self.actions.push(action);
     }
 
-    pub fn tick(&mut self, dtime: Time) {
+    pub fn tick(&mut self, dtime: Duration) {
         let mut forked_actions = Vec::new();
         for action in &mut self.actions {
             action.update(dtime);

--- a/hate/src/screen.rs
+++ b/hate/src/screen.rs
@@ -1,5 +1,5 @@
+use std::time::Duration;
 use context::Context;
-use time::Time;
 use event::Event;
 
 pub enum Command {
@@ -8,7 +8,7 @@ pub enum Command {
 }
 
 pub trait Screen {
-    fn tick(&mut self, context: &mut Context, dtime: Time);
+    fn tick(&mut self, context: &mut Context, dtime: Duration);
 
     fn handle_event(&mut self, context: &mut Context, event: Event);
 }

--- a/hate/src/screen_stack.rs
+++ b/hate/src/screen_stack.rs
@@ -1,6 +1,6 @@
+use std::time;
 use std::sync::mpsc;
 use context::Context;
-use time::Time;
 use event::Event;
 use screen::{Command, Screen};
 
@@ -19,7 +19,7 @@ impl Screens {
         self.screens.is_empty()
     }
 
-    pub fn tick(&mut self, context: &mut Context, dtime: Time) {
+    pub fn tick(&mut self, context: &mut Context, dtime: time::Duration) {
         self.screens.last_mut().unwrap().tick(context, dtime);
         self.handle_commands();
     }

--- a/hate/src/time.rs
+++ b/hate/src/time.rs
@@ -1,25 +1,8 @@
-use std::time;
+use std::time::Duration;
 
-// TODO: migrate to `std::time::Duration`
-// https://randomascii.wordpress.com/2012/02/13/dont-store-that-in-a-float/
-// https://www.reddit.com/r/rust/comments/6dct7o/float_duration_a_simple_floatingpoint_duration/
-
-/// Time in seconds
-#[derive(Copy, Clone, Debug, PartialEq, PartialOrd)]
-pub struct Time(pub f32);
-
-impl Time {
-    pub fn delta(self, other: Self) -> Self {
-        Time(self.0 - other.0)
-    }
-
-    pub fn from_duration(duration: time::Duration) -> Self {
-        let seconds = duration.as_secs() as f32;
-        let nanoseconds = duration.subsec_nanos() as f32;
-        Time(seconds + nanoseconds / 1_000_000_000.0)
-    }
-
-    pub fn to_duration(self) -> time::Duration {
-        time::Duration::from_millis((self.0 * 1000.0) as u64)
-    }
+/// Converts `time::Duration` to `f32` seconds.
+pub fn duration_to_f32(duration: Duration) -> f32 {
+    let seconds = duration.as_secs() as f32;
+    let nanoseconds = duration.subsec_nanos() as f32;
+    seconds + nanoseconds / 1_000_000_000.0
 }

--- a/src/game_view.rs
+++ b/src/game_view.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
-use hate::{Context, Scene, Sprite, Time};
+use std::time::Duration;
+use hate::{Context, Scene, Sprite};
 use hate::scene::Layer;
 use hate::scene::action::{self, Action};
 use core::map::{HexMap, PosHex};
@@ -91,7 +92,7 @@ impl GameView {
         self.add_action(action);
     }
 
-    pub fn tick(&mut self, context: &mut Context, dtime: Time) {
+    pub fn tick(&mut self, context: &mut Context, dtime: Duration) {
         self.scene.tick(dtime);
         self.scene.draw(context);
     }
@@ -157,7 +158,7 @@ impl GameView {
             let action = {
                 let layer = &self.layers().highlighted_tiles;
                 Box::new(action::Sequence::new(vec![
-                    Box::new(action::ChangeColorTo::new(&sprite, color, Time(0.3))),
+                    Box::new(action::ChangeColorTo::new(&sprite, color, Duration::from_millis(300))),
                     Box::new(action::Hide::new(layer, &sprite)),
                 ]))
             };
@@ -268,7 +269,7 @@ impl GameView {
         color_from[3] = 0.0;
         sprite.set_color(color_from);
         sprite.set_pos(hex_to_point(self.tile_size(), pos));
-        let time = Time(0.3);
+        let time = Duration::from_millis(300);
         let layer = &self.layers.highlighted_tiles;
         let action = Box::new(action::Sequence::new(vec![
             Box::new(action::Show::new(layer, &sprite)),

--- a/src/screen/main_menu.rs
+++ b/src/screen/main_menu.rs
@@ -1,4 +1,5 @@
-use hate::{self, Context, Event, Screen, Sprite, Time};
+use std::time;
+use hate::{self, Context, Event, Screen, Sprite};
 use hate::gui::{self, Gui};
 use hate::geom::Point;
 use screen;
@@ -59,7 +60,7 @@ impl MainMenu {
 }
 
 impl Screen for MainMenu {
-    fn tick(&mut self, context: &mut Context, _: Time) {
+    fn tick(&mut self, context: &mut Context, _: time::Duration) {
         let projection_matrix = context.projection_matrix();
         self.sprite.draw(context, projection_matrix);
         self.gui.draw(context);


### PR DESCRIPTION
Closes #190

Removed `hate::Context::new()` method. Just use `std::time:Duration` for everything.