### PR TITLE
ZComponents: Add `ids_collected` method, readme and example/test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,5 +42,5 @@ install:
 # TODO: test other crates
 script:
     - cargo build
-    - cargo test
+    - cargo test --all
     - cargo build --examples --manifest-path zcomponents/Cargo.toml

--- a/zcomponents/README.md
+++ b/zcomponents/README.md
@@ -1,5 +1,52 @@
-# ZComponents
+# `ZComponents` - a stupid component storage
 
-ZComponents is a stupid component storage.
+I find "serious" ECS to be an overkill for turn-based game logic,
+so I've created this simple library that does only one thing:
+stores your components.
 
-TODO: examples
+## Basic Example
+
+```rust
+#[macro_use]
+extern crate zcomponents;
+
+#[derive(PartialEq, Eq, Clone, Copy, Debug, Hash, Default)]
+pub struct Id(i32);
+
+#[derive(Clone, Debug)]
+pub struct SomeComponent(pub i32);
+
+#[derive(Clone, Debug)]
+pub struct SomeFlag;
+
+zcomponents_storage!(Storage<Id>: {
+    component: SomeComponent,
+    flag: SomeFlag,
+});
+
+let mut storage = Storage::new();
+
+let id0 = storage.alloc_id();
+storage.component.insert(id0, SomeComponent(0));
+
+let id1 = storage.alloc_id();
+storage.component.insert(id1, SomeComponent(1));
+storage.flag.insert(id1, SomeFlag);
+
+storage.component.get_mut(id0).0 += 1;
+
+if let Some(component) = storage.component.get_opt_mut(id1) {
+    component.0 += 1;
+}
+
+storage.flag.remove(id1);
+
+storage.remove(id0);
+```
+
+See a more advanced example [in crate's documentation](src/lib.rs).
+
+## Implementation
+
+It's implemented as a simple macro and a bunch of naive `HashMap`s
+so don't expect any outstanding performance.

--- a/zcomponents/src/lib.rs
+++ b/zcomponents/src/lib.rs
@@ -51,6 +51,11 @@ impl<Id: Hash + Eq + Copy, V: Clone> ComponentContainer<Id, V> {
     pub fn ids(&self) -> IdIter<Id, V> {
         IdIter::new(&self.data)
     }
+
+    /// Note: Allocates Vec in heap.
+    pub fn ids_collected(&self) -> Vec<Id> {
+        self.ids().collect()
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -111,6 +116,10 @@ macro_rules! zcomponents_storage {
 
             pub fn ids(&self) -> $crate::IdIter<$id_type, ()> {
                 $crate::IdIter::new(&self.ids)
+            }
+
+            pub fn ids_collected(&self) -> Vec<$id_type> {
+                self.ids().collect()
             }
 
             pub fn is_exist(&self, id: $id_type) -> bool {

--- a/zcomponents/src/lib.rs
+++ b/zcomponents/src/lib.rs
@@ -1,4 +1,88 @@
-// TODO: add debug!() logs everywhere
+//! TODO: that is this?
+//!
+//! ## Example:
+//!
+//! ```rust
+//! #[macro_use]
+//! extern crate zcomponents;
+//!
+//! #[derive(PartialEq, Eq, Clone, Copy, Debug, Hash, Default)]
+//! pub struct Id(i32);
+//!
+//! #[derive(Clone, Debug)]
+//! pub struct A {
+//!     value: i32,
+//! }
+//!
+//! #[derive(Clone, Debug)]
+//! pub struct B {
+//!     value: i32,
+//! }
+//!
+//! #[derive(Clone, Debug)]
+//! pub struct C;
+//!
+//! zcomponents_storage!(Storage<Id>: {
+//!     a: A,
+//!     b: B,
+//!     c: C,
+//! });
+//!
+//! fn main() {
+//!     // Create a new storage instance.
+//!     let mut storage = Storage::new();
+//!
+//!     // It doesn't store anything yet.
+//!     assert_eq!(storage.ids().count(), 0);
+//!
+//!     // Allocate a new id.
+//!     let id0 = storage.alloc_id();
+//!     assert_eq!(storage.ids().count(), 1);
+//!
+//!     // This Entity doesn't have any components assigned.
+//!     assert!(!storage.is_exist(id0));
+//!
+//!     storage.a.insert(id0, A { value: 0 });
+//!
+//!     // Now it has a component.
+//!     assert!(storage.is_exist(id0));
+//!
+//!     // Allocate another id.
+//!     let id1 = storage.alloc_id();
+//!     assert_eq!(storage.ids().count(), 2);
+//!
+//!     storage.a.insert(id1, A { value: 1 });
+//!     storage.b.insert(id1, B { value: 1 });
+//!
+//!     // Iterate over everything.
+//!     for id in storage.ids_collected() {
+//!         // We are not sure that this entity has the component,
+//!         // so we must use `get_opt`/`get_opt_mut` methods.
+//!         if let Some(a) = storage.a.get_opt_mut(id) {
+//!             a.value += 1;
+//!         }
+//!         if let Some(b) = storage.b.get_opt_mut(id) {
+//!             b.value += 1;
+//!             storage.c.insert(id, C);
+//!         }
+//!     }
+//!
+//!     // Iterate over `a` components.
+//!     for id in storage.a.ids_collected() {
+//!         // Since we are sure that component exists,
+//!         // we can just use `get`/`get_mut` version:
+//!         storage.a.get_mut(id).value += 1;
+//!     }
+//!
+//!     // Remove the component
+//!     storage.a.remove(id0);
+//!
+//!     // Remove the whole entity
+//!     storage.remove(id0);
+//!
+//!     assert!(!storage.is_exist(id0));
+//! }
+//! ```
 
 use std::collections::{hash_map, HashMap};
 use std::default::Default;

--- a/zcomponents/src/lib.rs
+++ b/zcomponents/src/lib.rs
@@ -26,6 +26,7 @@ impl<Id: Hash + Eq + Copy, V: Clone> ComponentContainer<Id, V> {
         self.data.get(&id)
     }
 
+    /// Note: panics if there's no such entity.
     pub fn get(&self, id: Id) -> &V {
         self.get_opt(id).unwrap()
     }
@@ -34,15 +35,18 @@ impl<Id: Hash + Eq + Copy, V: Clone> ComponentContainer<Id, V> {
         self.data.get_mut(&id)
     }
 
+    /// Note: panics if there's no such entity.
     pub fn get_mut(&mut self, id: Id) -> &mut V {
         self.get_opt_mut(id).unwrap()
     }
 
+    /// Note: panics if there's no such entity.
     pub fn insert(&mut self, id: Id, data: V) {
         assert!(self.get_opt(id).is_none());
         self.data.insert(id, data);
     }
 
+    /// Note: panics if there's no such entity.
     pub fn remove(&mut self, id: Id) {
         assert!(self.get_opt(id).is_some());
         self.data.remove(&id);

--- a/zcomponents/src/lib.rs
+++ b/zcomponents/src/lib.rs
@@ -93,7 +93,6 @@ macro_rules! zcomponents_storage {
         #[allow(dead_code)]
         impl $struct_name {
             pub fn new() -> Self {
-                debug!("$struct_name: new"); // TODO: check if it works as expected
                 Self {
                     $(
                         $component: $crate::ComponentContainer::new(),
@@ -107,7 +106,6 @@ macro_rules! zcomponents_storage {
                 let id = self.next_obj_id;
                 self.next_obj_id.0 += 1;
                 self.ids.insert(id, ());
-                debug!("$struct_name: alloc_id {:?}", id);
                 id
             }
 
@@ -118,16 +116,13 @@ macro_rules! zcomponents_storage {
             pub fn is_exist(&self, id: $id_type) -> bool {
                 $(
                     if self.$component.get_opt(id).is_some() {
-                        debug!("is_exist {:?}: true", id);
                         return true;
                     }
                 )*
-                debug!("is_exist {:?}: false", id);
                 false
             }
 
             pub fn remove(&mut self, id: $id_type) {
-                debug!("remove {:?}", id);
                 $(
                     if self.$component.get_opt(id).is_some() {
                         self.$component.remove(id);

--- a/zcomponents/src/lib.rs
+++ b/zcomponents/src/lib.rs
@@ -2,6 +2,7 @@
 
 use std::collections::{hash_map, HashMap};
 use std::default::Default;
+use std::fmt::Debug;
 use std::hash::Hash;
 
 #[derive(Debug, Clone)]
@@ -9,17 +10,16 @@ pub struct ComponentContainer<Id: Hash + Eq, V> {
     data: HashMap<Id, V>,
 }
 
-impl<Id: Hash + Eq + Copy, V: Clone> Default for ComponentContainer<Id, V> {
+impl<Id: Hash + Eq + Copy + Debug, V: Clone> Default for ComponentContainer<Id, V> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<Id: Hash + Eq + Copy, V: Clone> ComponentContainer<Id, V> {
+impl<Id: Hash + Eq + Copy + Debug, V: Clone> ComponentContainer<Id, V> {
     pub fn new() -> Self {
-        Self {
-            data: HashMap::new(),
-        }
+        let data = HashMap::new();
+        Self { data }
     }
 
     pub fn get_opt(&self, id: Id) -> Option<&V> {
@@ -28,7 +28,8 @@ impl<Id: Hash + Eq + Copy, V: Clone> ComponentContainer<Id, V> {
 
     /// Note: panics if there's no such entity.
     pub fn get(&self, id: Id) -> &V {
-        self.get_opt(id).unwrap()
+        self.get_opt(id)
+            .unwrap_or_else(|| panic!("Can't find {:?} id", id))
     }
 
     pub fn get_opt_mut(&mut self, id: Id) -> Option<&mut V> {
@@ -37,7 +38,8 @@ impl<Id: Hash + Eq + Copy, V: Clone> ComponentContainer<Id, V> {
 
     /// Note: panics if there's no such entity.
     pub fn get_mut(&mut self, id: Id) -> &mut V {
-        self.get_opt_mut(id).unwrap()
+        self.get_opt_mut(id)
+            .unwrap_or_else(|| panic!("Can't find {:?} id", id))
     }
 
     /// Note: panics if there's no such entity.


### PR DESCRIPTION
This PR:
- Adds `zcomponents/README.md`
- Adds `ids_collected` method to `ComponentContainer` and a storage itself
- Adds doctest example for `zcomponents`
- Replaces `.unwrap()`s with nicer custom error messages in `get`/`get_mut`
- Removes logging from the macro (as it breaks client code that has no `extern crate log;`)

Closes #144 
Part of #145 