### PR TITLE
Create objects only on completely empty tiles

### DIFF
--- a/src/core/execute.rs
+++ b/src/core/execute.rs
@@ -969,7 +969,7 @@ fn random_free_pos(state: &State) -> Option<PosHex> {
             q: thread_rng().gen_range(-radius.0, radius.0),
             r: thread_rng().gen_range(-radius.0, radius.0),
         };
-        if state.map().is_inboard(pos) && !state::is_tile_blocked(state, pos) {
+        if state::is_tile_plain_and_completely_free(state, pos) {
             return Some(pos);
         }
     }
@@ -990,7 +990,7 @@ fn random_free_sector_pos(state: &State, player_id: PlayerId) -> Option<PosHex> 
             },
             r: thread_rng().gen_range(-radius.0, radius.0),
         };
-        if state.map().is_inboard(pos) && !state::is_tile_blocked(state, pos) {
+        if state::is_tile_plain_and_completely_free(state, pos) {
             return Some(pos);
         }
     }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -56,7 +56,7 @@ pub struct Moves(pub i32);
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Jokers(pub i32);
 
-#[derive(Clone, Copy, Debug, Hash)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq)]
 pub enum TileType {
     Plain,
     Rocks,

--- a/src/core/state.rs
+++ b/src/core/state.rs
@@ -1,7 +1,7 @@
 use core::ability::PassiveAbility;
 use core::map::{self, PosHex};
 use core::utils;
-use core::{ObjId, PlayerId};
+use core::{ObjId, PlayerId, TileType};
 
 pub use self::private::State;
 
@@ -92,6 +92,18 @@ pub fn is_tile_blocked(state: &State, pos: PosHex) -> bool {
         }
     }
     false
+}
+
+pub fn is_tile_plain_and_completely_free(state: &State, pos: PosHex) -> bool {
+    if !state.map().is_inboard(pos) || state.map().tile(pos) != TileType::Plain {
+        return false;
+    }
+    for id in state.parts().pos.ids() {
+        if state.parts().pos.get(id).0 == pos {
+            return false;
+        }
+    }
+    true
 }
 
 pub fn ids_at(state: &State, pos: PosHex) -> Vec<ObjId> {


### PR DESCRIPTION
This PR adds `is_tile_plain_and_completely_free(state: &State, pos: PosHex) -> bool` function to `core::state` module.

Closes #260
Closes #261