### PR TITLE
Fix movement interruption

### DIFF
--- a/src/core/execute.rs
+++ b/src/core/execute.rs
@@ -52,7 +52,8 @@ fn execute_move_to(state: &mut State, cb: Cb, command: &command::MoveTo) {
     let tie_up_attack_status = try_execute_reaction_attacks(state, cb, id);
     if tie_up_attack_status == AttackStatus::Hit && state.parts().agent.get_opt(id).is_some() {
         // A degenerate move event just to spend agent's move point
-        let path = Path::new(vec![command.path.from()]);
+        let current_pos = state.parts().pos.get(id).0;
+        let path = Path::new(vec![current_pos]);
         do_move(state, cb, id, cost.take(), path);
         return;
     }


### PR DESCRIPTION
...when an agent was pushed back by a reaction attack.

The code was assuming agent's position to be constant.

Fixes #287 