### PR TITLE
AI agents act in the order of remoteness from enemies

### DIFF
--- a/src/core/ai/battle.rs
+++ b/src/core/ai/battle.rs
@@ -198,7 +198,9 @@ impl Ai {
     }
 
     pub fn command(&mut self, state: &State) -> Option<Command> {
-        for unit_id in state::players_agent_ids(state, self.id) {
+        let mut ids = state::players_agent_ids(state, self.id);
+        state::sort_agent_ids_by_distance_to_enemies(state, &mut ids);
+        for unit_id in ids {
             if let Some(summon_command) = self.try_summon_imp(state, unit_id) {
                 return Some(summon_command);
             }

--- a/src/core/map.rs
+++ b/src/core/map.rs
@@ -203,8 +203,8 @@ impl<T: Copy + Default + Debug> HexMap<T> {
         self.radius
     }
 
-    pub fn height(&self) -> i32 {
-        self.radius().0 * 2 + 1
+    pub fn height(&self) -> Distance {
+        Distance(self.radius().0 * 2 + 1)
     }
 
     pub fn iter(&self) -> HexIter {
@@ -322,6 +322,6 @@ mod tests {
     fn test_map_height() {
         let map: HexMap<u8> = HexMap::new(Distance(3));
         let height = map.height();
-        assert_eq!(height, 3 + 3 + 1);
+        assert_eq!(height, Distance(7));
     }
 }

--- a/src/core/state.rs
+++ b/src/core/state.rs
@@ -185,3 +185,19 @@ pub fn free_neighbor_positions(state: &State, origin: PosHex, count: i32) -> Vec
     }
     positions
 }
+
+pub fn sort_agent_ids_by_distance_to_enemies(state: &State, ids: &mut [ObjId]) {
+    ids.sort_unstable_by_key(|&id| {
+        let agent_player_id = state.parts().belongs_to.get(id).0;
+        let agent_pos = state.parts().pos.get(id).0;
+        let mut min_distance = map::Distance(state.map().height());
+        for enemy_id in enemy_agent_ids(state, agent_player_id) {
+            let enemy_pos = state.parts().pos.get(enemy_id).0;
+            let distance = map::distance_hex(agent_pos, enemy_pos);
+            if distance < min_distance {
+                min_distance = distance;
+            }
+        }
+        min_distance
+    });
+}

--- a/src/core/state.rs
+++ b/src/core/state.rs
@@ -190,7 +190,7 @@ pub fn sort_agent_ids_by_distance_to_enemies(state: &State, ids: &mut [ObjId]) {
     ids.sort_unstable_by_key(|&id| {
         let agent_player_id = state.parts().belongs_to.get(id).0;
         let agent_pos = state.parts().pos.get(id).0;
-        let mut min_distance = map::Distance(state.map().height());
+        let mut min_distance = state.map().height();
         for enemy_id in enemy_agent_ids(state, agent_player_id) {
             let enemy_pos = state.parts().pos.get(enemy_id).0;
             let distance = map::distance_hex(agent_pos, enemy_pos);

--- a/src/screen/battle/view.rs
+++ b/src/screen/battle/view.rs
@@ -8,7 +8,7 @@ use scene::action;
 use scene::{Action, Boxed, Layer, Scene, Sprite};
 
 use core::ability::Ability;
-use core::map::{HexMap, PosHex};
+use core::map::{HexMap, PosHex, Distance};
 use core::{self, command, movement};
 use core::{Jokers, Moves, ObjId, State, TileType};
 use geom::{self, hex_to_point};
@@ -56,8 +56,8 @@ impl Layers {
     }
 }
 
-pub fn tile_size(map_height: i32) -> f32 {
-    1.0 / ((map_height) as f32 * 0.75)
+pub fn tile_size(map_height: Distance) -> f32 {
+    1.0 / (map_height.0 as f32 * 0.75)
 }
 
 #[derive(Debug)]
@@ -114,7 +114,7 @@ impl BattleView {
         let images = Images::new(context)?;
         let layers = Layers::default();
         let scene = Scene::new(layers.clone().sorted());
-        let tile_size = tile_size(state.map().height()) * 1.0;
+        let tile_size = tile_size(state.map().height());
         let mut selection_marker = Sprite::from_image(
             images.selection.clone(),
             tile_size * 2.0 * geom::FLATNESS_COEFFICIENT,


### PR DESCRIPTION
Closes #303 

`sort_agent_ids_by_distance_to_enemies` is implemented in an extremely ineffective way, but the map is small and the number of agents is quite low, so it should work fine in practice, at least for now.

![](https://i.imgur.com/IlpOm6p.gif)