### PR TITLE
Tune `visualize_evnt_end_battle` timing

### DIFF
--- a/src/screen/battle/visualize.rs
+++ b/src/screen/battle/visualize.rs
@@ -435,11 +435,13 @@ fn visualize_event_end_battle(
     sprite.set_centered(true);
     sprite.set_color(invisible);
     Ok(seq(vec![
+        action::Sleep::new(time_s(1.0)).boxed(),
         action::Show::new(&view.layers().text, &sprite).boxed(),
         action::ChangeColorTo::new(&sprite, visible, time_s(0.5)).boxed(),
-        action::Sleep::new(time_s(3.0)).boxed(),
+        action::Sleep::new(time_s(2.0)).boxed(),
         action::ChangeColorTo::new(&sprite, invisible, time_s(1.0)).boxed(),
         action::Hide::new(&view.layers().text, &sprite).boxed(),
+        action::Sleep::new(time_s(1.0)).boxed(),
     ]))
 }
 


### PR DESCRIPTION
Add a small pause before the text is shown and wait until the text is disappeared completely before removing the battle screen from the stack.