### PR TITLE
Remove data duplication from `objects.ron`

### DIFF
--- a/src/core/tactical_map/ability.rs
+++ b/src/core/tactical_map/ability.rs
@@ -2,7 +2,7 @@ use core::map::Distance;
 use core::tactical_map::{Attacks, Strength};
 
 /// Active ability.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum Ability {
     Knockback,
     Club,
@@ -25,33 +25,33 @@ pub enum Ability {
 }
 
 // TODO: use named fields?
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Jump(pub Distance);
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Rage(pub Attacks);
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Heal(pub Strength);
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Bomb(pub Distance);
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 pub struct BombDemonic(pub Distance);
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 pub struct BombPush {
     pub throw_distance: Distance,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 pub struct BombPoison(pub Distance);
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 pub struct BombFire(pub Distance);
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 pub enum Status {
     Ready,
     Cooldown(i32), // TODO: i32 -> Rounds
@@ -72,7 +72,7 @@ fn default_status() -> Status {
     Status::Ready
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct RechargeableAbility {
     pub ability: Ability,
 
@@ -83,8 +83,8 @@ pub struct RechargeableAbility {
 }
 
 impl Ability {
-    pub fn to_string(self) -> String {
-        match self {
+    pub fn to_string(&self) -> String {
+        match *self {
             Ability::Knockback => "Knockback".into(),
             Ability::Club => "Club".into(),
             Ability::Jump(a) => format!("Jump-{}", (a.0).0),
@@ -107,7 +107,7 @@ impl Ability {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 pub enum PassiveAbility {
     HeavyImpact,
     SpawnPoisonCloudOnDeath,
@@ -118,7 +118,7 @@ pub enum PassiveAbility {
     Regenerate(Regenerate),
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Regenerate(pub Strength);
 
 impl PassiveAbility {

--- a/src/core/tactical_map/ai.rs
+++ b/src/core/tactical_map/ai.rs
@@ -179,7 +179,7 @@ impl Ai {
                 let command = Command::UseAbility(command::UseAbility {
                     id: agent_id,
                     pos,
-                    ability,
+                    ability: ability.clone(),
                 });
                 if check(state, &command).is_ok() {
                     return Some(command);

--- a/src/core/tactical_map/check.rs
+++ b/src/core/tactical_map/check.rs
@@ -91,7 +91,7 @@ fn check_command_end_turn(_: &State, _: &command::EndTurn) -> Result<(), Error> 
 fn check_command_use_ability(state: &State, command: &command::UseAbility) -> Result<(), Error> {
     check_agent_belongs_to_correct_player(state, command.id)?;
     check_agent_can_attack(state, command.id)?;
-    check_agent_ability_ready(state, command.id, command.ability)?;
+    check_agent_ability_ready(state, command.id, &command.ability)?;
     match command.ability {
         Ability::Knockback => check_ability_knockback(state, command.id, command.pos),
         Ability::Club => check_ability_club(state, command.id, command.pos),
@@ -280,7 +280,7 @@ fn try_get_actor(state: &State, id: ObjId) -> Result<&tactical_map::component::A
 fn check_agent_ability_ready(
     state: &State,
     id: ObjId,
-    expected_ability: Ability,
+    expected_ability: &Ability,
 ) -> Result<(), Error> {
     let mut found = false;
     let abilities = match state.parts().abilities.get_opt(id) {
@@ -288,7 +288,7 @@ fn check_agent_ability_ready(
         None => return Err(Error::BadActorType),
     };
     for ability in abilities {
-        if ability.ability == expected_ability {
+        if ability.ability == *expected_ability {
             found = true;
             if ability.status != ability::Status::Ready {
                 return Err(Error::AbilityIsNotReady);

--- a/src/core/tactical_map/execute.rs
+++ b/src/core/tactical_map/execute.rs
@@ -477,7 +477,7 @@ fn execute_planned_abilities(state: &mut State, cb: Cb) {
                 if planned.rounds <= 0 {
                     trace!("planned ability: ready!");
                     let c = command::UseAbility {
-                        ability: planned.ability,
+                        ability: planned.ability.clone(),
                         id: obj_id,
                         pos,
                     };
@@ -628,10 +628,10 @@ fn schedule_ability(state: &mut State, id: ObjId, ability: Ability) {
     schedule.planned.push(planned_ability);
 }
 
-fn refresh_scheduled_ability(state: &mut State, id: ObjId, ability: Ability) {
+fn refresh_scheduled_ability(state: &mut State, id: ObjId, ability: &Ability) {
     let schedule = state.parts_mut().schedule.get_mut(id);
     for planned_ability in &mut schedule.planned {
-        if planned_ability.ability == ability {
+        if planned_ability.ability == *ability {
             planned_ability.rounds = 2; // TODO: do not hardcode
             return;
         }
@@ -642,7 +642,7 @@ fn refresh_scheduled_ability(state: &mut State, id: ObjId, ability: Ability) {
 fn start_fire(state: &mut State, pos: PosHex) -> ExecuteContext {
     let mut context = ExecuteContext::default();
     if let Some(id) = state::obj_with_passive_ability_at(state, pos, PassiveAbility::Burn) {
-        refresh_scheduled_ability(state, id, Ability::Vanish);
+        refresh_scheduled_ability(state, id, &Ability::Vanish);
     } else {
         let effect_create = effect_create_object(state, "fire", pos);
         let id = state.alloc_id();
@@ -658,7 +658,7 @@ fn start_fire(state: &mut State, pos: PosHex) -> ExecuteContext {
 fn create_poison_cloud(state: &mut State, pos: PosHex) -> ExecuteContext {
     let mut context = ExecuteContext::default();
     if let Some(id) = state::obj_with_passive_ability_at(state, pos, PassiveAbility::Poison) {
-        refresh_scheduled_ability(state, id, Ability::Vanish);
+        refresh_scheduled_ability(state, id, &Ability::Vanish);
     } else {
         let effect_create = effect_create_object(state, "poison_cloud", pos);
         let id = state.alloc_id();
@@ -1072,7 +1072,7 @@ fn execute_use_ability(state: &mut State, cb: Cb, command: &command::UseAbility)
     let active_event = ActiveEvent::UseAbility(event::UseAbility {
         id: command.id,
         pos: command.pos,
-        ability: command.ability,
+        ability: command.ability.clone(),
     });
     let event = Event {
         active_event,

--- a/src/core/tactical_map/mod.rs
+++ b/src/core/tactical_map/mod.rs
@@ -31,26 +31,20 @@ impl Phase {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Serialize, Deserialize, Default, Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct ObjId(i32);
 
-impl Default for ObjId {
-    fn default() -> Self {
-        ObjId(0)
-    }
-}
-
-#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, PartialOrd)]
+#[derive(Serialize, Deserialize, Default, Clone, Copy, Debug, PartialEq, PartialOrd)]
 pub struct Strength(pub i32);
 
-#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, PartialOrd)]
+#[derive(Serialize, Deserialize, Default, Clone, Copy, Debug, PartialEq, PartialOrd)]
 pub struct Attacks(pub i32);
 
-#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, PartialOrd)]
+#[derive(Serialize, Deserialize, Default, Clone, Copy, Debug, PartialEq, PartialOrd)]
 pub struct Moves(pub i32);
 
 /// Move or Attack
-#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, PartialOrd)]
+#[derive(Serialize, Deserialize, Default, Clone, Copy, Debug, PartialEq, PartialOrd)]
 pub struct Jokers(pub i32);
 
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/src/core/tactical_map/mod.rs
+++ b/src/core/tactical_map/mod.rs
@@ -22,7 +22,7 @@ mod check;
 pub struct PlayerId(pub i32);
 
 /// An index of player's turn.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Phase(i32);
 
 impl Phase {
@@ -40,20 +40,20 @@ impl Default for ObjId {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, PartialOrd)]
 pub struct Strength(pub i32);
 
-#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, PartialOrd)]
 pub struct Attacks(pub i32);
 
-#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, PartialOrd)]
 pub struct Moves(pub i32);
 
 /// Move or Attack
-#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, PartialOrd)]
 pub struct Jokers(pub i32);
 
-#[derive(Clone, Copy, Debug, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum TileType {
     Plain,
     Rocks,

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ type ZResult<T = ()> = GameResult<T>;
 const APP_ID: &str = "zemeroth";
 const APP_AUTHOR: &str = "ozkriff";
 const ASSETS_DIR_NAME: &str = "assets";
-const ASSETS_HASHSUM: &str = "98d808e742fa169b3ff7dc249e93feb3";
+const ASSETS_HASHSUM: &str = "11e0ede08d585a946be57cc7fa0a320e";
 
 struct MainState {
     screens: screen::Screens,

--- a/src/screen/battle/mod.rs
+++ b/src/screen/battle/mod.rs
@@ -22,7 +22,7 @@ use ZResult;
 mod view;
 mod visualize;
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 enum Message {
     Exit,
     Deselect,
@@ -132,13 +132,13 @@ fn build_panel_agent_abilities(
     }
     let mut layout = ui::VLayout::new();
     let h = line_height();
-    for &ability in abilities {
+    for ability in abilities {
         let text = match ability.status {
             ability::Status::Ready => format!("[{}]", ability.ability.to_string()),
             ability::Status::Cooldown(n) => format!("[{} ({})]", ability.ability.to_string(), n),
         };
         let image = Text::new(context, &text, font)?.into_inner();
-        let msg = Message::Ability(ability.ability);
+        let msg = Message::Ability(ability.ability.clone());
         let button = ui::Button::new(context, image, h, gui.sender(), msg);
         layout.add(Box::new(button));
     }
@@ -422,7 +422,7 @@ impl Battle {
             return Ok(());
         }
         if self.state.map().is_inboard(pos) {
-            if let SelectionMode::Ability(ability) = self.mode {
+            if let SelectionMode::Ability(ability) = self.mode.clone() {
                 let selected_id = self.selected_agent_id.unwrap();
                 let command = command::Command::UseAbility(command::UseAbility {
                     id: selected_id,

--- a/src/screen/battle/view.rs
+++ b/src/screen/battle/view.rs
@@ -16,7 +16,7 @@ use screen::battle::visualize;
 use utils::time_s;
 use ZResult;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum SelectionMode {
     Normal,
     Ability(Ability),
@@ -210,9 +210,9 @@ impl BattleView {
         selected_id: ObjId,
         mode: &SelectionMode,
     ) -> ZResult {
-        match *mode {
+        match mode {
             SelectionMode::Normal => self.select_normal(state, map, selected_id),
-            SelectionMode::Ability(ability) => self.select_ability(state, selected_id, ability),
+            SelectionMode::Ability(ref ability) => self.select_ability(state, selected_id, ability),
         }
     }
 
@@ -246,13 +246,13 @@ impl BattleView {
         self.show_attackable_tiles(state, id)
     }
 
-    fn select_ability(&mut self, state: &State, selected_id: ObjId, ability: Ability) -> ZResult {
+    fn select_ability(&mut self, state: &State, selected_id: ObjId, ability: &Ability) -> ZResult {
         self.remove_highlights();
         let positions = state.map().iter();
         for pos in positions {
             let command = command::Command::UseAbility(command::UseAbility {
                 id: selected_id,
-                ability,
+                ability: ability.clone(),
                 pos,
             });
             if tactical_map::check(state, &command).is_ok() {


### PR DESCRIPTION
Closes #361 

Related to https://github.com/ozkriff/zemeroth_assets/commit/9532e8a59bc2e4bfbfb8b0008618beffa1cbbb84

Config diff example:

```diff
    "swordsman": [
        Blocker(()),
        Strength((
-           base_strength: 4,
            strength: 4,
        )),
        Agent((
            moves: 1,
            attacks: 1,
            jokers: 1,
            reactive_attacks: 1,
            attack_distance: 1,
            attack_strength: 2,
            attack_break: 1,
            move_points: 3,
-           base_moves: 1,
-           base_attacks: 1,
-           base_jokers: 1,
        )),
        Abilities([
            (ability: Jump(2), base_cooldown: 2),
            (ability: Rage(2), base_cooldown: 3),
            (ability: Dash, base_cooldown: 1),
         ]),
     ],
```