### PR TITLE
Arrange created objects in 'Line's

### DIFF
--- a/src/core/tactical_map/state.rs
+++ b/src/core/tactical_map/state.rs
@@ -121,6 +121,18 @@ pub fn is_tile_plain_and_completely_free(state: &State, pos: PosHex) -> bool {
     true
 }
 
+pub fn is_tile_completely_free(state: &State, pos: PosHex) -> bool {
+    if !state.map().is_inboard(pos) {
+        return false;
+    }
+    for id in state.parts().pos.ids() {
+        if state.parts().pos.get(id).0 == pos {
+            return false;
+        }
+    }
+    true
+}
+
 /// Are there any enemy agents on the adjacent tiles?
 pub fn check_enemies_around(state: &State, pos: PosHex, player_id: PlayerId) -> bool {
     for dir in map::dirs() {


### PR DESCRIPTION
This PR adds

```rust
pub enum Line {
    Any,
    Front,
    Middle,
    Back,
}
```

to describe where we want objects to be generated.

Seems to work fine:

![](https://i.imgur.com/2v20dua.png)

Even on giant maps:

![](https://i.imgur.com/6Rb9F9b.png)

Summoners will always be protected with other imps on the first turn now. :)

Closes #367 