### PR TITLE
Hit chances based on agents' stats

### DIFF
--- a/src/core/tactical_map/component.rs
+++ b/src/core/tactical_map/component.rs
@@ -46,9 +46,13 @@ pub struct Agent {
     // static
     pub attack_strength: tactical_map::Strength,
     pub attack_distance: map::Distance,
+    pub attack_accuracy: tactical_map::Accuracy,
 
     #[serde(default)]
     pub attack_break: tactical_map::Strength,
+
+    #[serde(default)]
+    pub dodge: tactical_map::Dodge,
 
     pub move_points: MovePoints,
     pub reactive_attacks: Attacks,

--- a/src/core/tactical_map/mod.rs
+++ b/src/core/tactical_map/mod.rs
@@ -47,6 +47,12 @@ pub struct Moves(pub i32);
 #[derive(Serialize, Deserialize, Default, Clone, Copy, Debug, PartialEq, PartialOrd)]
 pub struct Jokers(pub i32);
 
+#[derive(Serialize, Deserialize, Default, Clone, Copy, Debug, PartialEq, PartialOrd)]
+pub struct Accuracy(pub i32);
+
+#[derive(Serialize, Deserialize, Default, Clone, Copy, Debug, PartialEq, PartialOrd)]
+pub struct Dodge(pub i32);
+
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum TileType {
     Plain,

--- a/src/core/tactical_map/utils.rs
+++ b/src/core/tactical_map/utils.rs
@@ -21,6 +21,17 @@ pub fn clamp_max<T: PartialOrd>(value: T, max: T) -> T {
     }
 }
 
+pub fn clamp<T: PartialOrd>(value: T, min: T, max: T) -> T {
+    debug_assert!(min <= max, "min must be less than or equal to max");
+    if value < min {
+        min
+    } else if value > max {
+        max
+    } else {
+        value
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #[test]
@@ -35,5 +46,17 @@ mod tests {
         assert_eq!(super::clamp_max(1, 2), 1);
         assert_eq!(super::clamp_max(2, 2), 2);
         assert_eq!(super::clamp_max(3, 2), 2);
+    }
+
+    #[test]
+    fn test_clamp() {
+        let min = 0;
+        let max = 2;
+        assert_eq!(super::clamp(1, min, max), 1);
+        assert_eq!(super::clamp(0, min, max), 0);
+        assert_eq!(super::clamp(-1, min, max), 0);
+        assert_eq!(super::clamp(1, min, max), 1);
+        assert_eq!(super::clamp(2, min, max), 2);
+        assert_eq!(super::clamp(3, min, max), 2);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ type ZResult<T = ()> = GameResult<T>;
 const APP_ID: &str = "zemeroth";
 const APP_AUTHOR: &str = "ozkriff";
 const ASSETS_DIR_NAME: &str = "assets";
-const ASSETS_HASHSUM: &str = "11e0ede08d585a946be57cc7fa0a320e";
+const ASSETS_HASHSUM: &str = "c2154a1b84ba0884e4af04e431fe84e0";
 
 struct MainState {
     screens: screen::Screens,

--- a/src/screen/battle/mod.rs
+++ b/src/screen/battle/mod.rs
@@ -76,6 +76,10 @@ fn build_panel_agent_info(
             line(&format!("attack distance: {}", a.attack_distance.0))?;
         }
         line(&format!("attack strength: {}", a.attack_strength.0))?;
+        line(&format!("attack accuracy: {}", a.attack_accuracy.0))?;
+        if a.dodge.0 > 0 {
+            line(&format!("dodge: {}", a.dodge.0))?;
+        }
         line(&format!("move points: {}", a.move_points.0))?;
         if let Some(abilities) = parts.passive_abilities.get_opt(id) {
             if !abilities.0.is_empty() {
@@ -357,7 +361,7 @@ impl Battle {
             }
         }
         let map = self.pathfinder.map();
-        self.view.set_mode(state, map, id, &mode)?;
+        self.view.set_mode(state, context, map, id, &mode)?;
         self.mode = mode;
         Ok(())
     }


### PR DESCRIPTION
This PR adds `attack_accuracy` and `dodge` stats to `Agent` component and uses these fields for some basic hit chances math.

Wounded agents become less accurate in attacks.

Attacks with strength > 1 have additional hit chances - with reduced damage (each strength point gives 10% hit chance impovement).

![demo](https://i.imgur.com/XyKRoa8.gif)

Related to https://github.com/ozkriff/zemeroth_assets/commit/69e6fb34cd95012eb25613a16f016ab199f0598c

Closes #348 