### PR TITLE
Use names for Travis jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,19 +47,19 @@ script:
 
 jobs:
   include:
-  - env: FEATURE=check_assets
+  - name: check_assets
     rust: stable
     script:
       - git clone --depth=1 https://github.com/ozkriff/zemeroth_assets assets
       - RUST_LOG=zemeroth=info cargo run -- --check-assets
-  - env: FEATURE=fmt
+  - name: fmt
     rust: nightly-2018-10-01
     install:
       - rustup component add rustfmt-preview
       - rustfmt -V
     script:
       - cargo fmt --all -- --check
-  - env: FEATURE=clippy
+  - name: clippy
     rust: nightly-2018-10-01
     install:
       - rustup component add clippy-preview


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/662976/46882627-0324fe00-ce58-11e8-86ba-075b91b3f248.png)

After:

![image](https://user-images.githubusercontent.com/662976/46882646-1a63eb80-ce58-11e8-8b85-f311bb044ff9.png)

This hides an information about what rust channel/version is used, but think it's ok - you can always open the job and check the log.

Closes #372 
