### PR TITLE
edition = "2018"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,16 +62,16 @@ jobs:
       - git clone --depth=1 https://github.com/ozkriff/zemeroth_assets assets
       - RUST_LOG=zemeroth=info cargo run -- --check-assets
   - name: fmt
-    rust: nightly-2018-10-01
+    rust: stable
     install:
-      - rustup component add rustfmt-preview
+      - rustup component add rustfmt
       - rustfmt -V
     script:
       - cargo fmt --all -- --check
   - name: clippy
-    rust: nightly-2018-10-01
+    rust: nightly-2018-12-05
     install:
-      - rustup component add clippy-preview
+      - rustup component add clippy
       - cargo clippy -V
     script:
       - cargo clippy --verbose -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "zemeroth"
 version = "0.4.0"
 authors = ["Andrey Lesnikov <ozkriff@gmail.com>"]
+edition = "2018"
 license = "MIT/Apache-2.0"
 description = "A 2D turn-based hexagonal tactical game."
 
@@ -18,6 +19,6 @@ env_logger = "0.5"
 serde = "1.0"
 serde_derive = "1.0"
 num = { version = "0.2", default-features = false }
-ggwp-zgui = { path = "ggwp-zgui" }
-ggwp-zscene = { path = "ggwp-zscene" }
+ui = { path = "ggwp-zgui", package = "ggwp-zgui" }
+scene = { path = "ggwp-zscene", package = "ggwp-zscene" }
 zcomponents = { path = "zcomponents" }

--- a/ggwp-zgui/Cargo.toml
+++ b/ggwp-zgui/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ggwp-zgui"
 version = "0.1.0"
 authors = ["Andrey Lesnikov <ozkriff@gmail.com>"]
+edition = "2018"
 license = "MIT/Apache-2.0"
 description = "Tiny and opionated GUI library"
 keywords = ["ggez", "gamedev", "gui"]

--- a/ggwp-zgui/examples/absolute_coordinates.rs
+++ b/ggwp-zgui/examples/absolute_coordinates.rs
@@ -1,10 +1,9 @@
-extern crate ggez;
-extern crate ggwp_zgui as ui;
-
-use ggez::conf;
-use ggez::event;
-use ggez::graphics::{self, Font, Point2, Rect, Text};
-use ggez::{Context, ContextBuilder, GameResult};
+use ggez::{
+    conf, event,
+    graphics::{self, Font, Point2, Rect, Text},
+    Context, ContextBuilder, GameResult,
+};
+use ggwp_zgui as ui;
 
 #[derive(Clone, Copy, Debug)]
 enum Message {

--- a/ggwp-zgui/examples/layout.rs
+++ b/ggwp-zgui/examples/layout.rs
@@ -1,10 +1,9 @@
-extern crate ggez;
-extern crate ggwp_zgui as ui;
-
-use ggez::conf;
-use ggez::event;
-use ggez::graphics::{self, Font, Point2, Text};
-use ggez::{Context, ContextBuilder, GameResult};
+use ggez::{
+    conf, event,
+    graphics::{self, Font, Point2, Text},
+    Context, ContextBuilder, GameResult,
+};
+use ggwp_zgui as ui;
 
 #[derive(Clone, Copy, Debug)]
 enum Message {

--- a/ggwp-zgui/examples/nested.rs
+++ b/ggwp-zgui/examples/nested.rs
@@ -1,10 +1,9 @@
-extern crate ggez;
-extern crate ggwp_zgui as ui;
-
-use ggez::conf;
-use ggez::event;
-use ggez::graphics::{self, Font, Image, Point2, Rect, Text};
-use ggez::{Context, ContextBuilder, GameResult};
+use ggez::{
+    conf, event,
+    graphics::{self, Font, Image, Point2, Rect, Text},
+    Context, ContextBuilder, GameResult,
+};
+use ggwp_zgui as ui;
 
 #[derive(Clone, Copy, Debug)]
 enum Message {

--- a/ggwp-zgui/examples/pixel_coordinates.rs
+++ b/ggwp-zgui/examples/pixel_coordinates.rs
@@ -1,10 +1,9 @@
-extern crate ggez;
-extern crate ggwp_zgui as ui;
-
-use ggez::conf;
-use ggez::event;
-use ggez::graphics::{self, Font, Point2, Text};
-use ggez::{Context, ContextBuilder, GameResult};
+use ggez::{
+    conf, event,
+    graphics::{self, Font, Point2, Text},
+    Context, ContextBuilder, GameResult,
+};
+use ggwp_zgui as ui;
 
 #[derive(Clone, Copy, Debug)]
 enum Message {

--- a/ggwp-zgui/examples/remove.rs
+++ b/ggwp-zgui/examples/remove.rs
@@ -1,10 +1,9 @@
-extern crate ggez;
-extern crate ggwp_zgui as ui;
-
-use ggez::conf;
-use ggez::event;
-use ggez::graphics::{self, Font, Image, Point2, Text};
-use ggez::{Context, ContextBuilder, GameResult};
+use ggez::{
+    conf, event,
+    graphics::{self, Font, Image, Point2, Text},
+    Context, ContextBuilder, GameResult,
+};
+use ggwp_zgui as ui;
 
 #[derive(Clone, Copy, Debug)]
 enum Message {

--- a/ggwp-zgui/examples/text_button.rs
+++ b/ggwp-zgui/examples/text_button.rs
@@ -1,10 +1,9 @@
-extern crate ggez;
-extern crate ggwp_zgui as ui;
-
-use ggez::conf;
-use ggez::event;
-use ggez::graphics::{self, Font, Point2, Text};
-use ggez::{Context, ContextBuilder, GameResult};
+use ggez::{
+    conf, event,
+    graphics::{self, Font, Point2, Text},
+    Context, ContextBuilder, GameResult,
+};
+use ggwp_zgui as ui;
 
 #[derive(Clone, Copy, Debug)]
 enum Message {

--- a/ggwp-zgui/src/lib.rs
+++ b/ggwp-zgui/src/lib.rs
@@ -2,20 +2,18 @@
 
 /// Tiny and opinionated GUI
 ///
-
-#[macro_use]
-extern crate log;
-
-extern crate ggez;
-
-use std::{cell::RefCell, rc::Rc};
+use std::{
+    cell::RefCell,
+    fmt::Debug,
+    rc::Rc,
+    sync::mpsc::{channel, Receiver, Sender},
+};
 
 use ggez::{
     graphics::{self, Color, Image, Point2, Rect},
     Context, GameResult,
 };
-use std::fmt::Debug;
-use std::sync::mpsc::{channel, Receiver, Sender};
+use log::{debug, info};
 
 // TODO: What should we do if some widget changes its size?
 

--- a/ggwp-zscene/Cargo.toml
+++ b/ggwp-zscene/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ggwp-zscene"
 version = "0.1.0"
 authors = ["Andrey Lesnikov <ozkriff@gmail.com>"]
+edition = "2018"
 license = "MIT/Apache-2.0"
 description = "Scene and Actions for GGEZ"
 keywords = ["ggez", "gamedev", "2D"]

--- a/ggwp-zscene/examples/action.rs
+++ b/ggwp-zscene/examples/action.rs
@@ -1,14 +1,11 @@
-extern crate ggez;
-extern crate ggwp_zscene as scene;
-
 use std::time::Duration;
 
-use ggez::conf;
-use ggez::event;
-use ggez::graphics::{self, Font, Point2, Rect, Text, Vector2};
-use ggez::{Context, ContextBuilder, GameResult};
-use scene::action;
-use scene::{Boxed, Layer, Scene, Sprite};
+use ggez::{
+    conf, event,
+    graphics::{self, Font, Point2, Rect, Text, Vector2},
+    {Context, ContextBuilder, GameResult},
+};
+use ggwp_zscene::{action, Boxed, Layer, Scene, Sprite};
 
 #[derive(Debug, Clone, Default)]
 pub struct Layers {

--- a/ggwp-zscene/src/action/change_color_to.rs
+++ b/ggwp-zscene/src/action/change_color_to.rs
@@ -1,7 +1,8 @@
-use ggez::graphics::Color;
-use ggez::timer;
 use std::time::Duration;
-use {Action, Sprite};
+
+use ggez::{graphics::Color, timer};
+
+use crate::{Action, Sprite};
 
 #[derive(Debug)]
 pub struct ChangeColorTo {

--- a/ggwp-zscene/src/action/empty.rs
+++ b/ggwp-zscene/src/action/empty.rs
@@ -1,4 +1,4 @@
-use Action;
+use crate::Action;
 
 #[derive(Debug, Default)]
 pub struct Empty;

--- a/ggwp-zscene/src/action/fork.rs
+++ b/ggwp-zscene/src/action/fork.rs
@@ -1,4 +1,4 @@
-use Action;
+use crate::Action;
 
 #[derive(Debug)]
 pub struct Fork {

--- a/ggwp-zscene/src/action/hide.rs
+++ b/ggwp-zscene/src/action/hide.rs
@@ -1,4 +1,4 @@
-use {Action, Layer, Sprite};
+use crate::{Action, Layer, Sprite};
 
 #[derive(Debug)]
 pub struct Hide {

--- a/ggwp-zscene/src/action/mod.rs
+++ b/ggwp-zscene/src/action/mod.rs
@@ -1,15 +1,9 @@
-use std::fmt::Debug;
-use std::time::Duration;
+use std::{fmt::Debug, time::Duration};
 
-pub use action::change_color_to::ChangeColorTo;
-pub use action::empty::Empty;
-pub use action::fork::Fork;
-pub use action::hide::Hide;
-pub use action::move_by::MoveBy;
-pub use action::sequence::Sequence;
-pub use action::set_color::SetColor;
-pub use action::show::Show;
-pub use action::sleep::Sleep;
+pub use crate::action::{
+    change_color_to::ChangeColorTo, empty::Empty, fork::Fork, hide::Hide, move_by::MoveBy,
+    sequence::Sequence, set_color::SetColor, show::Show, sleep::Sleep,
+};
 
 mod change_color_to;
 mod empty;

--- a/ggwp-zscene/src/action/move_by.rs
+++ b/ggwp-zscene/src/action/move_by.rs
@@ -1,7 +1,8 @@
-use ggez::graphics::Vector2;
-use ggez::timer;
 use std::time::Duration;
-use {Action, Sprite};
+
+use ggez::{graphics::Vector2, timer};
+
+use crate::{Action, Sprite};
 
 #[derive(Debug)]
 pub struct MoveBy {

--- a/ggwp-zscene/src/action/sequence.rs
+++ b/ggwp-zscene/src/action/sequence.rs
@@ -1,6 +1,6 @@
-use std::collections::VecDeque;
-use std::time::Duration;
-use Action;
+use std::{collections::VecDeque, time::Duration};
+
+use crate::Action;
 
 #[derive(Debug)]
 pub struct Sequence {

--- a/ggwp-zscene/src/action/set_color.rs
+++ b/ggwp-zscene/src/action/set_color.rs
@@ -1,5 +1,6 @@
 use ggez::graphics::Color;
-use {Action, Sprite};
+
+use crate::{Action, Sprite};
 
 #[derive(Debug)]
 pub struct SetColor {

--- a/ggwp-zscene/src/action/show.rs
+++ b/ggwp-zscene/src/action/show.rs
@@ -1,4 +1,4 @@
-use {Action, Layer, Sprite};
+use crate::{Action, Layer, Sprite};
 
 #[derive(Debug)]
 pub struct Show {

--- a/ggwp-zscene/src/action/sleep.rs
+++ b/ggwp-zscene/src/action/sleep.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
-use Action;
+
+use crate::Action;
 
 #[derive(Debug)]
 pub struct Sleep {

--- a/ggwp-zscene/src/lib.rs
+++ b/ggwp-zscene/src/lib.rs
@@ -1,17 +1,15 @@
 #![warn(bare_trait_objects)]
 
-extern crate ggez;
-
-use std::cell::RefCell;
-use std::rc::Rc;
-use std::time::Duration;
+use std::{cell::RefCell, rc::Rc, time::Duration};
 
 use ggez::{Context, GameResult};
 
 // TODO: z-order? (https://github.com/ozkriff/zemeroth/issues/319)
 
-pub use action::{Action, Boxed};
-pub use sprite::Sprite;
+pub use crate::{
+    action::{Action, Boxed},
+    sprite::Sprite,
+};
 
 pub mod action;
 

--- a/ggwp-zscene/src/sprite.rs
+++ b/ggwp-zscene/src/sprite.rs
@@ -1,9 +1,9 @@
-use std::cell::RefCell;
-use std::path::Path;
-use std::rc::Rc;
+use std::{cell::RefCell, path::Path, rc::Rc};
 
-use ggez::graphics::{self, Point2, Rect, Vector2};
-use ggez::{Context, GameResult};
+use ggez::{
+    graphics::{self, Point2, Rect, Vector2},
+    Context, GameResult,
+};
 
 #[derive(Debug, Clone)]
 struct SpriteData {
@@ -63,7 +63,8 @@ impl Sprite {
         dimensions.scale(data.param.scale.x, data.param.scale.y);
         data.offset.x = -dimensions.w * offset.x;
         data.offset.y = -dimensions.h * offset.y;
-        data.param.dest += data.offset - old_offset;
+        let offset = data.offset;
+        data.param.dest += offset - old_offset;
     }
 
     pub fn draw(&self, context: &mut Context) -> GameResult<()> {

--- a/src/core/campaign/mod.rs
+++ b/src/core/campaign/mod.rs
@@ -1,4 +1,6 @@
-use core::tactical_map::{scenario::Scenario, state::BattleResult, PlayerId};
+use serde_derive::{Deserialize, Serialize};
+
+use crate::core::tactical_map::{scenario::Scenario, state::BattleResult, PlayerId};
 
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq)]
 pub enum Mode {
@@ -156,7 +158,7 @@ impl State {
 
 #[cfg(test)]
 mod tests {
-    use core::{
+    use crate::core::{
         campaign::{Award, CampaignNode, Mode, Plan, State},
         tactical_map::{
             scenario::{self, Line, Scenario},

--- a/src/core/map.rs
+++ b/src/core/map.rs
@@ -1,6 +1,7 @@
 use std::{fmt::Debug, iter::repeat};
 
 use num::{Num, Signed};
+use serde_derive::{Deserialize, Serialize};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct Distance(pub i32);
@@ -312,7 +313,7 @@ impl Iterator for DirIter {
 
 #[cfg(test)]
 mod tests {
-    use core::map::{Distance, HexMap};
+    use crate::core::map::{Distance, HexMap};
 
     #[test]
     fn test_map_height() {

--- a/src/core/tactical_map/ability.rs
+++ b/src/core/tactical_map/ability.rs
@@ -1,5 +1,9 @@
-use core::map::Distance;
-use core::tactical_map::{Attacks, Strength};
+use serde_derive::{Deserialize, Serialize};
+
+use crate::core::{
+    map::Distance,
+    tactical_map::{Attacks, Strength},
+};
 
 /// Active ability.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/src/core/tactical_map/ai.rs
+++ b/src/core/tactical_map/ai.rs
@@ -1,12 +1,16 @@
-use core::map::{self, Distance, HexMap};
-use core::tactical_map::{
-    ability::{self, Ability},
-    check,
-    command::{self, Command},
-    movement::{self, Path, Pathfinder},
-    state,
-    utils::shuffle_vec,
-    ObjId, PlayerId, State,
+use log::info;
+
+use crate::core::{
+    map::{self, Distance, HexMap},
+    tactical_map::{
+        ability::{self, Ability},
+        check,
+        command::{self, Command},
+        movement::{self, Path, Pathfinder},
+        state,
+        utils::shuffle_vec,
+        ObjId, PlayerId, State,
+    },
 };
 
 fn does_agent_have_ability_summon(state: &State, id: ObjId) -> bool {

--- a/src/core/tactical_map/apply.rs
+++ b/src/core/tactical_map/apply.rs
@@ -1,4 +1,6 @@
-use core::tactical_map::{
+use log::debug;
+
+use crate::core::tactical_map::{
     ability::{self, Ability},
     component::{self, Component},
     effect::{self, Effect},

--- a/src/core/tactical_map/check.rs
+++ b/src/core/tactical_map/check.rs
@@ -1,9 +1,13 @@
-use core::map::{self, Distance, PosHex};
-use core::tactical_map::{
-    self,
-    ability::{self, Ability},
-    command::{self, Command},
-    state, Attacks, Jokers, Moves, ObjId, State,
+use log::trace;
+
+use crate::core::{
+    map::{self, Distance, PosHex},
+    tactical_map::{
+        self,
+        ability::{self, Ability},
+        command::{self, Command},
+        state, Attacks, Jokers, Moves, ObjId, State,
+    },
 };
 
 pub fn check(state: &State, command: &Command) -> Result<(), Error> {

--- a/src/core/tactical_map/command.rs
+++ b/src/core/tactical_map/command.rs
@@ -1,5 +1,7 @@
-use core::map::PosHex;
-use core::tactical_map::{ability::Ability, movement::Path, ObjId, PlayerId};
+use crate::core::{
+    map::PosHex,
+    tactical_map::{ability::Ability, movement::Path, ObjId, PlayerId},
+};
 
 #[derive(Debug, Clone)]
 pub enum Command {

--- a/src/core/tactical_map/component.rs
+++ b/src/core/tactical_map/component.rs
@@ -1,11 +1,15 @@
 use ron;
+use serde_derive::{Deserialize, Serialize};
+use zcomponents::zcomponents_storage;
 
-use core::map;
-use core::tactical_map::{
-    self,
-    ability::{Ability, PassiveAbility, RechargeableAbility},
-    effect::Timed,
-    Attacks, Jokers, MovePoints, Moves, ObjId, Phase, PlayerId,
+use crate::core::{
+    map,
+    tactical_map::{
+        self,
+        ability::{Ability, PassiveAbility, RechargeableAbility},
+        effect::Timed,
+        Attacks, Jokers, MovePoints, Moves, ObjId, Phase, PlayerId,
+    },
 };
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]

--- a/src/core/tactical_map/effect.rs
+++ b/src/core/tactical_map/effect.rs
@@ -1,4 +1,5 @@
-use core::tactical_map::{component::Component, Phase, PosHex, Strength};
+use crate::core::tactical_map::{component::Component, Phase, PosHex, Strength};
+use serde_derive::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Copy, PartialEq, Serialize, Deserialize)]
 pub enum Duration {

--- a/src/core/tactical_map/event.rs
+++ b/src/core/tactical_map/event.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use core::tactical_map::{
+use crate::core::tactical_map::{
     ability::{Ability, PassiveAbility},
     effect::{self, Effect},
     movement::Path,

--- a/src/core/tactical_map/execute.rs
+++ b/src/core/tactical_map/execute.rs
@@ -1,20 +1,23 @@
 use std::collections::HashMap;
 
+use log::{debug, error, trace};
 use rand::{thread_rng, Rng};
 
-use core::map::{self, Dir, PosHex};
-use core::tactical_map::{
-    self,
-    ability::{self, Ability, PassiveAbility},
-    apply::apply,
-    check::{check, Error},
-    command::{self, Command},
-    component::{self, Component},
-    effect::{self, Duration, Effect},
-    event::{self, ActiveEvent, Event},
-    movement::Path,
-    state::{self, BattleResult, State},
-    utils, Moves, ObjId, Phase, PlayerId, Strength,
+use crate::core::{
+    map::{self, Dir, PosHex},
+    tactical_map::{
+        self,
+        ability::{self, Ability, PassiveAbility},
+        apply::apply,
+        check::{check, Error},
+        command::{self, Command},
+        component::{self, Component},
+        effect::{self, Duration, Effect},
+        event::{self, ActiveEvent, Event},
+        movement::Path,
+        state::{self, BattleResult, State},
+        utils, Moves, ObjId, Phase, PlayerId, Strength,
+    },
 };
 
 #[derive(PartialEq, Clone, Copy, Debug)]
@@ -1158,7 +1161,7 @@ fn choose_who_to_summon(state: &State) -> String {
 mod tests {
     use std::collections::HashMap;
 
-    use core::tactical_map::{effect::Effect, ObjId};
+    use crate::core::tactical_map::{effect::Effect, ObjId};
 
     use super::ExecuteContext;
 

--- a/src/core/tactical_map/mod.rs
+++ b/src/core/tactical_map/mod.rs
@@ -1,8 +1,10 @@
 use std::default::Default;
 
-use core::{map::PosHex, tactical_map::movement::MovePoints};
+use serde_derive::{Deserialize, Serialize};
 
-pub use core::tactical_map::{check::check, execute::execute, state::State};
+use crate::core::{map::PosHex, tactical_map::movement::MovePoints};
+
+pub use crate::core::tactical_map::{check::check, execute::execute, state::State};
 
 pub mod ability;
 pub mod ai;

--- a/src/core/tactical_map/movement.rs
+++ b/src/core/tactical_map/movement.rs
@@ -1,7 +1,11 @@
 use std::{collections::VecDeque, slice::Windows};
 
-use core::map::{dirs, Dir, Distance, HexMap, PosHex};
-use core::tactical_map::{ability::PassiveAbility, state, ObjId, State, TileType};
+use serde_derive::{Deserialize, Serialize};
+
+use crate::core::{
+    map::{dirs, Dir, Distance, HexMap, PosHex},
+    tactical_map::{ability::PassiveAbility, state, ObjId, State, TileType},
+};
 
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct MovePoints(pub i32);
@@ -31,8 +35,7 @@ impl Default for Tile {
     }
 }
 
-// TODO: const (see https://github.com/rust-lang/rust/issues/24111 )
-pub fn max_cost() -> MovePoints {
+pub const fn max_cost() -> MovePoints {
     MovePoints(i32::max_value())
 }
 
@@ -45,7 +48,7 @@ pub fn tile_cost(state: &State, _: ObjId, _: PosHex, pos: PosHex) -> MovePoints 
         for &ability in &state.parts().passive_abilities.get(id).0 {
             match ability {
                 PassiveAbility::SpikeTrap | PassiveAbility::Burn | PassiveAbility::Poison => {
-                    return MovePoints(4)
+                    return MovePoints(4);
                 }
                 _ => {}
             }
@@ -243,7 +246,7 @@ impl Pathfinder {
 
 #[cfg(test)]
 mod tests {
-    use core::tactical_map::{
+    use crate::core::tactical_map::{
         movement::{Path, Step},
         PosHex,
     };

--- a/src/core/tactical_map/scenario.rs
+++ b/src/core/tactical_map/scenario.rs
@@ -1,9 +1,12 @@
 use rand::{thread_rng, Rng};
+use serde_derive::{Deserialize, Serialize};
 
-use core::map::{self, PosHex};
-use core::tactical_map::{
-    state::{self, State},
-    PlayerId,
+use crate::core::{
+    map::{self, PosHex},
+    tactical_map::{
+        state::{self, State},
+        PlayerId,
+    },
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/core/tactical_map/state.rs
+++ b/src/core/tactical_map/state.rs
@@ -1,16 +1,22 @@
-use core::map::{self, PosHex};
-use core::tactical_map::{ability::PassiveAbility, utils, ObjId, PlayerId, Strength, TileType};
+use crate::core::{
+    map::{self, PosHex},
+    tactical_map::{ability::PassiveAbility, utils, ObjId, PlayerId, Strength, TileType},
+};
 
 pub use self::private::{BattleResult, State};
 
 mod private {
-    use core::map::{self, HexMap};
-    use core::tactical_map::{
-        command::{self, Command},
-        component::{Component, Parts, Prototypes},
-        execute,
-        scenario::{self, Scenario},
-        ObjId, PlayerId, TileType,
+    use log::error;
+
+    use crate::core::{
+        map::{self, HexMap},
+        tactical_map::{
+            command::{self, Command},
+            component::{Component, Parts, Prototypes},
+            execute,
+            scenario::{self, Scenario},
+            ObjId, PlayerId, TileType,
+        },
     };
 
     #[derive(Clone, Debug)]
@@ -107,7 +113,7 @@ mod private {
         }
 
         // TODO: make visible only for `apply`
-        pub(in core) fn prototype_for(&self, name: &str) -> Vec<Component> {
+        pub(in crate::core) fn prototype_for(&self, name: &str) -> Vec<Component> {
             let prototypes = &self.prototypes.0;
             prototypes[name].clone()
         }
@@ -120,23 +126,23 @@ mod private {
     /// Mutators. Be carefull with them!
     impl State {
         // TODO: check that it's called only from apply.rs!
-        pub(in core) fn parts_mut(&mut self) -> &mut Parts {
+        pub(in crate::core) fn parts_mut(&mut self) -> &mut Parts {
             &mut self.parts
         }
 
-        pub(in core) fn map_mut(&mut self) -> &mut HexMap<TileType> {
+        pub(in crate::core) fn map_mut(&mut self) -> &mut HexMap<TileType> {
             &mut self.map
         }
 
-        pub(in core) fn set_player_id(&mut self, new_value: PlayerId) {
+        pub(in crate::core) fn set_player_id(&mut self, new_value: PlayerId) {
             self.player_id = new_value;
         }
 
-        pub(in core) fn set_battle_result(&mut self, result: BattleResult) {
+        pub(in crate::core) fn set_battle_result(&mut self, result: BattleResult) {
             self.battle_result = Some(result);
         }
 
-        pub(in core) fn alloc_id(&mut self) -> ObjId {
+        pub(in crate::core) fn alloc_id(&mut self) -> ObjId {
             self.parts.alloc_id()
         }
     }

--- a/src/geom.rs
+++ b/src/geom.rs
@@ -1,6 +1,6 @@
 use ggez::graphics::Point2;
 
-use core::map::{hex_round, PosHex};
+use crate::core::map::{hex_round, PosHex};
 
 const SQRT_OF_3: f32 = 1.732_05;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,34 +1,13 @@
 #![windows_subsystem = "windows"]
 #![warn(bare_trait_objects)]
 
-#[macro_use]
-extern crate log;
-
-#[macro_use]
-extern crate serde_derive;
-
-#[macro_use]
-extern crate zcomponents;
-
-#[allow(unused_imports)] // TODO: I'm not sure what's going on in nightly
-#[macro_use]
-extern crate structopt;
-
-extern crate env_logger;
-extern crate ggez;
-extern crate ggwp_zgui as ui;
-extern crate ggwp_zscene as scene;
-extern crate num;
-extern crate rand;
-extern crate ron;
-extern crate serde;
-
 use ggez::{
     conf, event,
     filesystem::Filesystem,
     graphics::{self, Point2, Rect},
     Context, ContextBuilder, GameResult,
 };
+use log::info;
 use structopt::StructOpt;
 
 mod core;

--- a/src/screen/battle/mod.rs
+++ b/src/screen/battle/mod.rs
@@ -4,29 +4,34 @@ use ggez::{
     graphics::{self, Font, Point2, Text},
     Context,
 };
+use log::{debug, info};
 use scene::{action, Action, Boxed};
 use ui::{self, Gui};
 
-use core::map::PosHex;
-use core::tactical_map::{
-    self, ability,
-    ability::Ability,
-    ai::Ai,
-    check, command,
-    component::Prototypes,
-    effect,
-    movement::Pathfinder,
-    scenario,
-    state::{self, BattleResult},
-    ObjId, PlayerId, State,
+use crate::{
+    core::{
+        map::PosHex,
+        tactical_map::{
+            self, ability,
+            ability::Ability,
+            ai::Ai,
+            check, command,
+            component::Prototypes,
+            effect,
+            movement::Pathfinder,
+            scenario,
+            state::{self, BattleResult},
+            ObjId, PlayerId, State,
+        },
+    },
+    geom,
+    screen::{
+        battle::view::{make_action_create_map, BattleView, SelectionMode},
+        Screen, Transition,
+    },
+    utils::{self, time_s},
+    ZResult,
 };
-use geom;
-use screen::{
-    battle::view::{make_action_create_map, BattleView, SelectionMode},
-    Screen, Transition,
-};
-use utils::{self, time_s};
-use ZResult;
 
 mod view;
 mod visualize;

--- a/src/screen/battle/view.rs
+++ b/src/screen/battle/view.rs
@@ -7,15 +7,19 @@ use ggez::{
 use rand::{thread_rng, Rng};
 use scene::{action, Action, Boxed, Layer, Scene, Sprite};
 
-use core::map::{self, Distance, HexMap, PosHex};
-use core::tactical_map::{
-    self, ability::Ability, command, execute::hit_chance, movement, Jokers, Moves, ObjId, State,
-    TileType,
+use crate::{
+    core::{
+        map::{self, Distance, HexMap, PosHex},
+        tactical_map::{
+            self, ability::Ability, command, execute::hit_chance, movement, Jokers, Moves, ObjId,
+            State, TileType,
+        },
+    },
+    geom::{self, hex_to_point},
+    screen::battle::visualize,
+    utils::time_s,
+    ZResult,
 };
-use geom::{self, hex_to_point};
-use screen::battle::visualize;
-use utils::time_s;
-use ZResult;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum SelectionMode {

--- a/src/screen/battle/visualize.rs
+++ b/src/screen/battle/visualize.rs
@@ -4,21 +4,26 @@ use ggez::{
     graphics::{Color, Point2, Text, Vector2},
     nalgebra, Context,
 };
+use log::{debug, info};
 use rand::{thread_rng, Rng};
 use scene::{action, Action, Boxed, Sprite};
 
-use core::map::PosHex;
-use core::tactical_map::{
-    ability::Ability,
-    effect::{self, Effect},
-    event::{self, ActiveEvent, Event},
-    execute::{hit_chance, ApplyPhase},
-    state, ObjId, PlayerId, State,
+use crate::{
+    core::{
+        map::PosHex,
+        tactical_map::{
+            ability::Ability,
+            effect::{self, Effect},
+            event::{self, ActiveEvent, Event},
+            execute::{hit_chance, ApplyPhase},
+            state, ObjId, PlayerId, State,
+        },
+    },
+    geom,
+    screen::battle::view::BattleView,
+    utils::time_s,
+    ZResult,
 };
-use geom;
-use screen::battle::view::BattleView;
-use utils::time_s;
-use ZResult;
 
 fn seq(actions: Vec<Box<dyn Action>>) -> Box<dyn Action> {
     action::Sequence::new(actions).boxed()

--- a/src/screen/campaign/mod.rs
+++ b/src/screen/campaign/mod.rs
@@ -7,15 +7,17 @@ use ggez::{
     graphics::{self, Font, Point2, Text},
     Context,
 };
+use log::info;
 use ui::{self, Gui};
 
-use core::{
-    campaign::{Mode, State},
-    tactical_map::{scenario, state::BattleResult, PlayerId},
+use crate::{
+    core::{
+        campaign::{Mode, State},
+        tactical_map::{scenario, state::BattleResult, PlayerId},
+    },
+    screen::{self, Screen, Transition},
+    utils, ZResult,
 };
-use screen::{self, Screen, Transition};
-use utils;
-use ZResult;
 
 #[derive(Clone, Debug)]
 enum Message {

--- a/src/screen/main_menu.rs
+++ b/src/screen/main_menu.rs
@@ -7,13 +7,15 @@ use ggez::{
     graphics::{Font, Point2, Text},
     Context,
 };
+use log::debug;
 use scene::Sprite;
 use ui::{self, Gui};
 
-use core::tactical_map::state;
-use screen::{self, Screen, Transition};
-use utils;
-use ZResult;
+use crate::{
+    core::tactical_map::state,
+    screen::{self, Screen, Transition},
+    utils, ZResult,
+};
 
 #[derive(Copy, Clone, Debug)]
 enum Message {

--- a/src/screen/mod.rs
+++ b/src/screen/mod.rs
@@ -1,3 +1,4 @@
+use log::info;
 use std::{fmt::Debug, time::Duration};
 
 use ggez::{
@@ -6,7 +7,7 @@ use ggez::{
     Context,
 };
 
-use ZResult;
+use crate::ZResult;
 
 mod battle;
 mod campaign;

--- a/src/screen/strategy_map/mod.rs
+++ b/src/screen/strategy_map/mod.rs
@@ -7,13 +7,15 @@ use ggez::{
     graphics::{self, Font, Point2, Text},
     Context,
 };
+use log::info;
 use scene::{Layer, Scene, Sprite};
 use ui::{self, Gui};
 
-use core::tactical_map::state;
-use screen::{self, Screen, Transition};
-use utils;
-use ZResult;
+use crate::{
+    core::tactical_map::state,
+    screen::{self, Screen, Transition},
+    utils, ZResult,
+};
 
 #[derive(Copy, Clone, Debug)]
 enum Message {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,9 +1,10 @@
 use std::{io::Read, path::Path, process, time::Duration};
 
 use ggez::{filesystem::Filesystem, Context};
+use log::{error, info};
 use serde::de::DeserializeOwned;
 
-use ZResult;
+use crate::ZResult;
 
 pub fn time_s(s: f32) -> Duration {
     let ms = s * 1000.0;

--- a/zcomponents/Cargo.toml
+++ b/zcomponents/Cargo.toml
@@ -2,6 +2,7 @@
 name = "zcomponents"
 version = "0.1.1"
 authors = ["Andrey Lesnikov <ozkriff@gmail.com>"]
+edition = "2018"
 license = "MIT/Apache-2.0"
 description = "ZComponents is a stupid component storage"
 repository = "https://github.com/ozkriff/zemeroth"

--- a/zcomponents/README.md
+++ b/zcomponents/README.md
@@ -10,8 +10,7 @@ stores your components.
 ## Basic Example
 
 ```rust
-#[macro_use]
-extern crate zcomponents;
+use zcomponents::zcomponents_storage;
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug, Hash, Default)]
 pub struct Id(i32);

--- a/zcomponents/src/lib.rs
+++ b/zcomponents/src/lib.rs
@@ -7,8 +7,7 @@
 //! ## Example:
 //!
 //! ```rust
-//! #[macro_use]
-//! extern crate zcomponents;
+//! use zcomponents::zcomponents_storage;
 //!
 //! #[derive(PartialEq, Eq, Clone, Copy, Debug, Hash, Default)]
 //! pub struct Id(i32);
@@ -90,10 +89,12 @@
 
 #![warn(bare_trait_objects)]
 
-use std::collections::{hash_map, HashMap};
-use std::default::Default;
-use std::fmt::Debug;
-use std::hash::Hash;
+use std::{
+    collections::{hash_map, HashMap},
+    default::Default,
+    fmt::Debug,
+    hash::Hash,
+};
 
 #[derive(Debug, Clone)]
 pub struct ComponentContainer<Id: Hash + Eq, V> {
@@ -144,7 +145,7 @@ impl<Id: Hash + Eq + Copy + Debug, V: Clone> ComponentContainer<Id, V> {
         self.data.remove(&id);
     }
 
-    pub fn ids(&self) -> IdIter<Id, V> {
+    pub fn ids(&self) -> IdIter<'_, Id, V> {
         IdIter::new(&self.data)
     }
 
@@ -155,7 +156,7 @@ impl<Id: Hash + Eq + Copy + Debug, V: Clone> ComponentContainer<Id, V> {
 }
 
 #[derive(Clone, Debug)]
-pub struct IdIter<'a, Id: 'a, V: 'a> {
+pub struct IdIter<'a, Id, V> {
     iter: hash_map::Iter<'a, Id, V>,
 }
 


### PR DESCRIPTION
This PR:
- Moves all crates to 2018 edition;
- Updates most of the imports (`crate::` everywhere!);
- Removes all `extern crate` items;
- Changes all `macro_use` attributes to direct macro imports;
- Switches to stable channel for `rustfmt`;
- Switches to nightly-2018-12-05 for `clippy`;
- Employs some new lifetime elision in `zcomponents`' iterator code;

(The `foo/mod.rs` -> `foo.rs` mass rename will happen in a separate PR)

Part of #379 