### PR TITLE
blood splatters and weapon flashes

### DIFF
--- a/src/core/map.rs
+++ b/src/core/map.rs
@@ -229,7 +229,7 @@ impl<T: Copy + Default + Debug> HexMap<T> {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize)]
 pub enum Dir {
     SouthEast,
     East,

--- a/src/core/tactical_map/apply.rs
+++ b/src/core/tactical_map/apply.rs
@@ -208,7 +208,7 @@ fn apply_effect_instant(state: &mut State, id: ObjId, effect: &Effect) {
     debug!("effect::apply_instant: {:?} ({})", effect, effect.to_str());
     match *effect {
         Effect::Create(ref effect) => apply_effect_create(state, id, effect),
-        Effect::Kill => apply_effect_kill(state, id),
+        Effect::Kill(ref effect) => apply_effect_kill(state, id, effect),
         Effect::Vanish => apply_effect_vanish(state, id),
         Effect::Stun => apply_effect_stun(state, id),
         Effect::Heal(ref effect) => apply_effect_heal(state, id, effect),
@@ -224,7 +224,7 @@ fn apply_effect_create(state: &mut State, id: ObjId, effect: &effect::Create) {
     add_components(state, id, &effect.components);
 }
 
-fn apply_effect_kill(state: &mut State, id: ObjId) {
+fn apply_effect_kill(state: &mut State, id: ObjId, _: &effect::Kill) {
     let parts = state.parts_mut();
     parts.remove(id);
 }

--- a/src/core/tactical_map/component.rs
+++ b/src/core/tactical_map/component.rs
@@ -40,6 +40,14 @@ pub struct Meta {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct BelongsTo(pub PlayerId);
 
+#[derive(Serialize, Deserialize, PartialEq, Clone, Copy, Debug)]
+pub enum WeaponType {
+    Slash,
+    Smash,
+    Pierce,
+    Claw,
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct Agent {
     // dynamic
@@ -51,6 +59,7 @@ pub struct Agent {
     pub attack_strength: tactical_map::Strength,
     pub attack_distance: map::Distance,
     pub attack_accuracy: tactical_map::Accuracy,
+    pub weapon_type: WeaponType,
 
     #[serde(default)]
     pub attack_break: tactical_map::Strength,

--- a/src/core/tactical_map/effect.rs
+++ b/src/core/tactical_map/effect.rs
@@ -1,5 +1,9 @@
-use crate::core::tactical_map::{component::Component, Phase, PosHex, Strength};
 use serde_derive::{Deserialize, Serialize};
+
+use crate::core::{
+    map::Dir,
+    tactical_map::{component::Component, Phase, PosHex, Strength},
+};
 
 #[derive(Clone, Debug, Copy, PartialEq, Serialize, Deserialize)]
 pub enum Duration {
@@ -27,7 +31,7 @@ pub struct Timed {
 #[derive(Clone, Debug, PartialEq, Deserialize)]
 pub enum Effect {
     Create(Create),
-    Kill,
+    Kill(Kill),
     Vanish,
     Stun,
     Heal(Heal),
@@ -42,7 +46,7 @@ impl Effect {
     pub fn to_str(&self) -> &str {
         match *self {
             Effect::Create(_) => "Create",
-            Effect::Kill => "Kill",
+            Effect::Kill(_) => "Kill",
             Effect::Vanish => "Vanish",
             Effect::Stun => "Stun",
             Effect::Heal(_) => "Heal",
@@ -75,6 +79,12 @@ impl Lasting {
 pub struct Wound {
     pub damage: Strength,
     pub armor_break: Strength,
+    pub dir: Option<Dir>,
+}
+
+#[derive(Clone, Debug, PartialEq, Deserialize)]
+pub struct Kill {
+    pub dir: Option<Dir>,
 }
 
 #[derive(Clone, PartialEq, Debug, Deserialize)]

--- a/src/core/tactical_map/event.rs
+++ b/src/core/tactical_map/event.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use crate::core::tactical_map::{
     ability::{Ability, PassiveAbility},
+    component::WeaponType,
     effect::{self, Effect},
     movement::Path,
     state::BattleResult,
@@ -52,6 +53,7 @@ pub struct Attack {
     pub attacker_id: ObjId,
     pub target_id: ObjId,
     pub mode: AttackMode,
+    pub weapon_type: WeaponType,
 }
 
 #[derive(Debug, Clone)]

--- a/src/core/tactical_map/execute.rs
+++ b/src/core/tactical_map/execute.rs
@@ -137,10 +137,12 @@ fn execute_attack_internal(
     command: &command::Attack,
     mode: event::AttackMode,
 ) -> AttackStatus {
+    let weapon_type = state.parts().agent.get(command.attacker_id).weapon_type;
     let active_event = ActiveEvent::Attack(event::Attack {
         attacker_id: command.attacker_id,
         target_id: command.target_id,
         mode,
+        weapon_type,
     });
     let mut target_effects = Vec::new();
     let mut is_kill = false;

--- a/src/core/tactical_map/execute.rs
+++ b/src/core/tactical_map/execute.rs
@@ -147,7 +147,7 @@ fn execute_attack_internal(
     let mut target_effects = Vec::new();
     let mut is_kill = false;
     if let Some(effect) = try_attack(state, command.attacker_id, command.target_id) {
-        if let Effect::Kill = effect {
+        if let Effect::Kill(_) = effect {
             is_kill = true;
         }
         target_effects.push(effect);
@@ -839,14 +839,16 @@ fn correct_damage_with_armor(
 
 fn wound_or_kill(state: &State, id: ObjId, damage: tactical_map::Strength) -> Effect {
     let parts = state.parts();
-    let strength = parts.strength.get(id);
-    if strength.strength > damage {
+    let strength = parts.strength.get(id).strength;
+    let dir = None; // Let's assume that this is not a directed attack.
+    if strength > damage {
         Effect::Wound(effect::Wound {
             damage,
-            armor_break: tactical_map::Strength(0),
+            armor_break: tactical_map::Strength(0), // !!!
+            dir,
         })
     } else {
-        Effect::Kill
+        Effect::Kill(effect::Kill { dir })
     }
 }
 
@@ -884,13 +886,23 @@ fn try_attack(state: &State, attacker_id: ObjId, target_id: ObjId) -> Option<Eff
     }
     let damage = correct_damage_with_armor(state, target_id, damage);
     let attack_break = utils::clamp_max(agent_attacker.attack_break, target_armor);
+    let dir = {
+        let attacker_pos = state.parts().pos.get(attacker_id).0;
+        let target_pos = state.parts().pos.get(target_id).0;
+        if map::distance_hex(attacker_pos, target_pos).0 > 1 {
+            None
+        } else {
+            Some(Dir::get_dir_from_to(attacker_pos, target_pos))
+        }
+    };
     let effect = if target_strength > damage {
         Effect::Wound(effect::Wound {
             damage,
             armor_break: attack_break,
+            dir,
         })
     } else {
-        Effect::Kill
+        Effect::Kill(effect::Kill { dir })
     };
     Some(effect)
 }
@@ -1163,7 +1175,13 @@ fn choose_who_to_summon(state: &State) -> String {
 mod tests {
     use std::collections::HashMap;
 
-    use crate::core::tactical_map::{effect::Effect, ObjId};
+    use crate::core::{
+        map::Dir,
+        tactical_map::{
+            effect::{self, Effect},
+            ObjId,
+        },
+    };
 
     use super::ExecuteContext;
 
@@ -1188,7 +1206,10 @@ mod tests {
     #[test]
     fn test_merge_with_hashmap() {
         let mut instant_effects1 = HashMap::new();
-        instant_effects1.insert(ObjId(0), vec![Effect::Kill, Effect::Stun]);
+        let effect_kill = Effect::Kill(effect::Kill {
+            dir: Some(Dir::East),
+        });
+        instant_effects1.insert(ObjId(0), vec![effect_kill.clone(), Effect::Stun]);
         let mut context1 = ExecuteContext {
             instant_effects: instant_effects1,
             ..Default::default()
@@ -1202,7 +1223,7 @@ mod tests {
         let mut instant_effects_expected = HashMap::new();
         instant_effects_expected.insert(
             ObjId(0),
-            vec![Effect::Kill, Effect::Stun, Effect::Vanish, Effect::Miss],
+            vec![effect_kill, Effect::Stun, Effect::Vanish, Effect::Miss],
         );
         let context_expected = ExecuteContext {
             instant_effects: instant_effects_expected,

--- a/src/geom.rs
+++ b/src/geom.rs
@@ -1,4 +1,5 @@
-use ggez::graphics::Point2;
+use ggez::graphics::{Point2, Vector2};
+use rand::{thread_rng, Rng};
 
 use crate::core::map::{hex_round, PosHex};
 
@@ -19,4 +20,13 @@ pub fn point_to_hex(size: f32, mut point: Point2) -> PosHex {
     let q = (point.x * SQRT_OF_3 / 3.0 - point.y / 3.0) / size;
     let r = point.y * 2.0 / 3.0 / size;
     hex_round(PosHex { q, r })
+}
+
+pub fn rand_tile_offset(size: f32, radius: f32) -> Vector2 {
+    assert!(radius >= 0.0);
+    let r = size * radius;
+    Vector2::new(
+        thread_rng().gen_range(-r, r),
+        thread_rng().gen_range(-r, r) * FLATNESS_COEFFICIENT,
+    )
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ type ZResult<T = ()> = GameResult<T>;
 const APP_ID: &str = "zemeroth";
 const APP_AUTHOR: &str = "ozkriff";
 const ASSETS_DIR_NAME: &str = "assets";
-const ASSETS_HASHSUM: &str = "1756a424ff728bfa10679d381ab02a17";
+const ASSETS_HASHSUM: &str = "18e7de361e74471aeaec3f209ef63c3e";
 
 struct MainState {
     screens: screen::Screens,

--- a/src/screen/battle/view.rs
+++ b/src/screen/battle/view.rs
@@ -414,12 +414,9 @@ fn make_action_show_tile(state: &State, view: &BattleView, at: PosHex) -> ZResul
 fn make_action_grass(view: &BattleView, at: PosHex) -> ZResult<Box<dyn Action>> {
     let screen_pos = hex_to_point(view.tile_size(), at);
     let mut sprite = Sprite::from_image(view.images.grass.clone(), view.tile_size() * 2.0);
-    let n = view.tile_size() * 0.5;
     let v_offset = view.tile_size() * 0.5; // depends on the image
-    let screen_pos_grass = Point2::new(
-        screen_pos.x + thread_rng().gen_range(-n, n),
-        screen_pos.y - v_offset + thread_rng().gen_range(-n, n) * geom::FLATNESS_COEFFICIENT,
-    );
+    let mut screen_pos_grass = screen_pos + geom::rand_tile_offset(view.tile_size(), 0.5);
+    screen_pos_grass.y -= v_offset;
     sprite.set_centered(true);
     sprite.set_pos(screen_pos_grass);
     Ok(action::Show::new(&view.layers().grass, &sprite).boxed())

--- a/src/screen/battle/view.rs
+++ b/src/screen/battle/view.rs
@@ -88,6 +88,10 @@ pub struct Images {
     pub dot: Image,
     pub blood: Image,
     pub shadow: Image,
+    pub attack_slash: Image,
+    pub attack_smash: Image,
+    pub attack_pierce: Image,
+    pub attack_claws: Image,
 }
 
 impl Images {
@@ -101,6 +105,10 @@ impl Images {
             dot: Image::new(context, "/dot.png")?,
             blood: Image::new(context, "/blood.png")?,
             shadow: Image::new(context, "/shadow.png")?,
+            attack_slash: Image::new(context, "/slash.png")?,
+            attack_smash: Image::new(context, "/smash.png")?,
+            attack_pierce: Image::new(context, "/pierce.png")?,
+            attack_claws: Image::new(context, "/claw.png")?,
         })
     }
 }

--- a/src/screen/battle/view.rs
+++ b/src/screen/battle/view.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, time::Duration};
 
 use ggez::{
-    graphics::{Color, Font, Image, Point2, Text /*, Vector2*/},
+    graphics::{Color, Font, Image, Text},
     Context,
 };
 use rand::{thread_rng, Rng};

--- a/src/screen/battle/visualize.rs
+++ b/src/screen/battle/visualize.rs
@@ -103,22 +103,23 @@ fn show_blood_spot(view: &mut BattleView, at: PosHex) -> ZResult<Box<dyn Action>
 
 fn show_dust_at_pos(view: &mut BattleView, at: PosHex) -> ZResult<Box<dyn Action>> {
     let point = geom::hex_to_point(view.tile_size(), at);
-    let count = 8;
+    let count = 9;
     show_dust(view, point, count)
 }
 
 fn show_dust(view: &mut BattleView, at: Point2, count: i32) -> ZResult<Box<dyn Action>> {
     let mut actions = Vec::new();
     for i in 0..count {
-        let k = thread_rng().gen_range(0.9, 1.1);
-        let visible = [0.8 * k, 0.8 * k, 0.7 * k, 0.8].into();
+        let k = thread_rng().gen_range(0.8, 1.2);
+        let visible = [0.8 * k, 0.8 * k, 0.7 * k, 0.8 * k].into();
         let invisible = Color { a: 0.0, ..visible };
-        let scale = thread_rng().gen_range(0.2, 0.5);
+        let scale = thread_rng().gen_range(0.2, 0.4);
         let size = view.tile_size() * 2.0 * scale;
         let vector = {
             let max = std::f32::consts::PI * 2.0;
             let rot = nalgebra::Rotation2::new((max / count as f32) * i as f32);
-            let mut vector = rot * Vector2::new(view.tile_size() * 0.5, 0.0);
+            let n = thread_rng().gen_range(0.4, 0.6);
+            let mut vector = rot * Vector2::new(view.tile_size() * n, 0.0);
             vector.y *= geom::FLATNESS_COEFFICIENT;
             vector
         };

--- a/src/screen/battle/visualize.rs
+++ b/src/screen/battle/visualize.rs
@@ -196,7 +196,7 @@ fn arc_move(view: &mut BattleView, sprite: &Sprite, diff: Vector2) -> Box<dyn Ac
     let len = nalgebra::norm(&diff);
     let min_height = view.tile_size() * 0.5;
     let base_height = view.tile_size() * 2.0;
-    let min_time = 0.2;
+    let min_time = 0.25;
     let base_time = 0.3;
     let height = min_height + base_height * (len / 1.0);
     let time = time_s(min_time + base_time * (len / 1.0));

--- a/src/screen/battle/visualize.rs
+++ b/src/screen/battle/visualize.rs
@@ -498,7 +498,6 @@ fn visualize_event_attack(
     actions.push(action_sprite_move_to);
     actions.push(fork(action_shadow_move_from));
     actions.push(action_sprite_move_from);
-    actions.push(action::Sleep::new(time_s(0.1)).boxed());
     Ok(seq(actions))
 }
 


### PR DESCRIPTION
This PR:
- Removes unneeded 0.1s pause from attack visualizer;
- Tweaks the colors of dust effect;
-  Increases the minimum time of an arc more action;
- Adds weapon flashes of four types: slash, smash, pierce and claw;
- Adds directed dynamic blood splatters.

Demo: ![](https://i.imgur.com/HqgHmOH.gif)

Depends on https://github.com/ozkriff/zemeroth_assets_src/commit/1f1813eff115dcafe1910e8fb5cbaccd1d9e2ffa

Closes #86  
Closes #400