### PR TITLE
progress bar on updated good-web-game fix

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -136,6 +136,7 @@ fn main() -> GameResult {
     ggez::start(
         conf::Conf {
             cache: conf::Cache::Index,
+            loading: conf::Loading::Embedded,
             ..Default::default()
         },
         |mut context| {


### PR DESCRIPTION
backporting hivewar's progress bar config