### PR TITLE
GGEZ: v0.4 -> 0.5.0-rc.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 language: rust
 
-# TODO: find a way to install SDL2 without sudo and disable it:
-sudo: true
-
 addons:
   apt:
     update: true
     packages:
-    - libasound2-dev
+      - libasound2-dev
+      - libudev-dev
 
 rust:
   - nightly
@@ -22,30 +20,8 @@ os:
   - osx
   - windows
 
-before_install:
-  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then
-        wget http://libsdl.org/release/SDL2-2.0.5.tar.gz
-        && tar -xzvf SDL2-2.0.5.tar.gz
-        && pushd SDL2-2.0.5
-        && ./configure --prefix=/usr
-        && make
-        && sudo make install
-        && popd;
-    fi
-  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
-        brew update && brew install sdl2;
-    fi
-  - if [ "${TRAVIS_OS_NAME}" = "windows" ]; then
-        curl -O https://www.libsdl.org/release/SDL2-devel-2.0.5-VC.zip
-        && ls
-        && 7z x SDL2-devel-2.0.5-VC.zip
-        && ls
-        && cp SDL2-2.0.5/lib/x64/* .
-        && ls;
-    fi
-
 before_script:
-- rustup component list
+  - rustup component list
 
 script:
   - cargo build --all
@@ -67,7 +43,7 @@ jobs:
     script:
       - cargo fmt --all -- --check
   - name: clippy
-    rust: nightly-2018-12-05
+    rust: stable
     install:
       - rustup component add clippy
       - cargo clippy -V

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,12 +13,13 @@ dependencies = [
 
 [[package]]
 name = "alga"
-version = "0.5.4"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "approx 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-complex 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "approx 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libm 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-complex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -29,6 +30,24 @@ dependencies = [
  "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "andrew"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "line_drawing 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusttype 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xdg 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xml-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "android_glue"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ansi_term"
@@ -53,6 +72,14 @@ dependencies = [
 name = "approx"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "approx"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "arrayvec"
@@ -129,18 +156,32 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "0.7.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "bitflags"
-version = "1.0.4"
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bytecount"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "byteorder"
 version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bytes"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "bzip2"
@@ -161,6 +202,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo_metadata"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.34 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,6 +230,15 @@ dependencies = [
 name = "cfg-if"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cgl"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gleam 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "cgmath"
@@ -226,15 +288,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "cocoa"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "objc 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "color_quant"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "core-foundation"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "core-foundation-sys"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "core-graphics"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -270,6 +371,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-epoch 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "deflate"
 version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,12 +459,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlib"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libloading 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "downcast-rs"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "draw_state"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "either"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "env_logger"
@@ -318,16 +506,48 @@ dependencies = [
 ]
 
 [[package]]
-name = "euclid"
-version = "0.17.3"
+name = "error-chain"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "euclid"
+version = "0.19.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "euclid_macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "euclid_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "fnv"
 version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -345,11 +565,15 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "gcc"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "generic-array"
-version = "0.8.3"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -394,62 +618,50 @@ dependencies = [
 ]
 
 [[package]]
-name = "gfx_glyph"
-version = "0.10.2"
+name = "gfx_window_glutin"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "gfx 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gfx_core 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "ordered-float 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusttype 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "twox-hash 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-normalization 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "xi-unicode 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "gfx_window_sdl"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "gfx 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx_core 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx_device_gl 0.15.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "sdl2 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glutin 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ggez"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.5.0-rc.0"
+source = "git+https://github.com/ozkriff/ggez?rev=7699cb33b#7699cb33bf962996594f40df539969eee7d59fe8"
 dependencies = [
  "app_dirs2 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "approx 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gfx_core 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx_device_gl 0.15.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "gfx_glyph 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "gfx_window_sdl 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "image 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gfx_window_glutin 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gilrs 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glutin 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glyph_brush 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "image 0.20.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "lyon 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "nalgebra 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "rodio 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusttype 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sdl2 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lyon 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mint 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nalgebra 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rodio 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
- "smart-default 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "skeptic 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smart-default 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "zip 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winit 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zip 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ggwp-zgui"
 version = "0.1.0"
 dependencies = [
- "ggez 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ggez 0.5.0-rc.0 (git+https://github.com/ozkriff/ggez?rev=7699cb33b)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -457,7 +669,7 @@ dependencies = [
 name = "ggwp-zscene"
 version = "0.1.0"
 dependencies = [
- "ggez 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ggez 0.5.0-rc.0 (git+https://github.com/ozkriff/ggez?rev=7699cb33b)",
 ]
 
 [[package]]
@@ -467,6 +679,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "color_quant 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lzw 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gilrs"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libudev-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -480,9 +707,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "gl_generator"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "khronos_api 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xml-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gleam"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gl_generator 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "glob"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "glutin"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "android_glue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cgl 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cocoa 0.18.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gl_generator 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "objc 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "shared_library 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-client 0.21.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winit 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "x11-dl 2.18.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "glyph_brush"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "glyph_brush_layout 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hashbrown 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ordered-float 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusttype 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "seahash 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "glyph_brush_layout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rusttype 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xi-unicode 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "heck"
@@ -507,18 +805,19 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.19.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "gif 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "jpeg-decoder 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "lzw 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-derive 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-iter 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-rational 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-rational 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "png 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiff 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -530,11 +829,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "iovec"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "itoa"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "jpeg-decoder"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -552,8 +866,8 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "lazy_static"
-version = "0.2.11"
+name = "khronos_api"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -563,11 +877,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lewton"
-version = "0.5.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "ogg 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ogg 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -586,9 +901,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "libloading"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libm"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libudev-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "line_drawing"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "lock_api"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "log"
@@ -608,36 +963,46 @@ dependencies = [
 
 [[package]]
 name = "lyon"
-version = "0.10.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lyon_tessellation 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lyon_algorithms 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lyon_tessellation 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lyon_algorithms"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lyon_path 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sid 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "lyon_geom"
-version = "0.10.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "euclid 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "lyon_path"
-version = "0.10.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lyon_geom 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lyon_geom 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "lyon_tessellation"
-version = "0.10.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lyon_path 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lyon_path 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sid 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -647,8 +1012,24 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "mach"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "matrixmultiply"
-version = "0.1.15"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rawpointer 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -673,27 +1054,80 @@ dependencies = [
 ]
 
 [[package]]
-name = "msdos_time"
-version = "0.1.6"
+name = "memmap"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "time 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "nalgebra"
-version = "0.14.4"
+name = "memoffset"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "minimp3"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "alga 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "approx 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "generic-array 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "matrixmultiply 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-complex 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "minimp3-sys 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slice-deque 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "minimp3-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mint"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "nalgebra"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "alga 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "approx 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matrixmultiply 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mint 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-complex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nix"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nix"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -711,16 +1145,6 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.1.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-iter 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "num"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -728,14 +1152,6 @@ dependencies = [
  "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-iter 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-rational 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -777,15 +1193,6 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.1.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "num-rational"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -807,8 +1214,24 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "num_cpus"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "objc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "malloc_buf 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ogg"
-version = "0.4.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -825,16 +1248,57 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "0.5.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "osmesa-sys"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "shared_library 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "owning_ref"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "peeking_take_while"
 version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "percent-encoding"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -875,13 +1339,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick-error"
-version = "1.2.2"
+name = "pulldown-cmark"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
-name = "quote"
-version = "0.3.15"
+name = "quick-error"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -991,6 +1458,27 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "rayon"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon-core 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1044,8 +1532,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rodio"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cgmath 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1053,7 +1549,8 @@ dependencies = [
  "cpal 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hound 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lewton 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lewton 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "minimp3 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1072,6 +1569,14 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "rustc-hash"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1081,16 +1586,24 @@ dependencies = [
 
 [[package]]
 name = "rusttype"
-version = "0.5.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "approx 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "approx 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-deque 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ordered-float 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ordered-float 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "stb_truetype 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "ryu"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "safemem"
@@ -1098,25 +1611,27 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "sdl2"
-version = "0.31.0"
+name = "same-file"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "sdl2-sys 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "sdl2-sys"
-version = "0.31.0"
+name = "scoped_threadpool"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
+
+[[package]]
+name = "scopeguard"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "seahash"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "semver"
@@ -1124,6 +1639,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1150,6 +1666,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "shell32-sys"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1167,13 +1702,69 @@ dependencies = [
 ]
 
 [[package]]
-name = "smart-default"
-version = "0.2.0"
+name = "skeptic"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytecount 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cargo_metadata 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pulldown-cmark 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "slice-deque"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mach 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "smallvec"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "smart-default"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.23 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "smithay-client-toolkit"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "andrew 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dlib 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-client 0.21.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-commons 0.21.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-protocols 0.21.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "stb_truetype"
@@ -1215,16 +1806,6 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "0.11.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "syn"
 version = "0.15.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -1234,11 +1815,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "synom"
-version = "0.11.3"
+name = "tempdir"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1276,13 +1858,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.1.41"
+name = "tiff"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lzw 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-derive 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1291,14 +1874,6 @@ version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "twox-hash"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "rand 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1312,11 +1887,6 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "unicode-normalization"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "unicode-segmentation"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1324,11 +1894,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "unicode-width"
 version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "unicode-xid"
-version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1350,6 +1915,14 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "uuid"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "vec_map"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1363,6 +1936,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "walkdir"
+version = "2.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.21.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "downcast-rs 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-commons 0.21.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-scanner 0.21.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-sys 0.21.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wayland-commons"
+version = "0.21.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nix 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-sys 0.21.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.21.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-client 0.21.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-commons 0.21.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-scanner 0.21.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-sys 0.21.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.21.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "xml-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.21.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "dlib 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "which"
@@ -1419,6 +2054,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "winit"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "android_glue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cocoa 0.18.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "image 0.20.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "objc 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smithay-client-toolkit 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-client 0.21.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "x11-dl 2.18.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "x11-dl"
+version = "2.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "xdg"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1437,6 +2105,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "xml-rs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "zcomponents"
 version = "0.1.1"
 
@@ -1445,7 +2118,7 @@ name = "zemeroth"
 version = "0.4.0"
 dependencies = [
  "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ggez 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ggez 0.5.0-rc.0 (git+https://github.com/ozkriff/ggez?rev=7699cb33b)",
  "ggwp-zgui 0.1.0",
  "ggwp-zscene 0.1.0",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1459,23 +2132,25 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "0.3.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bzip2 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "msdos_time 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crc32fast 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "podio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [metadata]
 "checksum adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7e522997b529f05601e05166c07ed17789691f562762c7f3b987263d2dedee5c"
 "checksum aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9a933f4e58658d7b12defcf96dc5c720f20832deebe3e0a19efd3b6aaeeb9e"
-"checksum alga 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "88c4144cd393075e782c633b4f9c5dea4811aed18ed59f518ae2ca2b553e3d09"
+"checksum alga 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "104e81d8a5813ac86ef14f6bef070d81de6da950c51648a8df8fe877f9316189"
 "checksum alsa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b0edcbbf9ef68f15ae1b620f722180b82a98b6f0628d30baa6b8d2a5abc87d58"
+"checksum andrew 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "62ea7024f6f4d203bede7c0c9cdafa3cbda3a9e0fa04d349008496cc95b8f11b"
+"checksum android_glue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "000444226fcff248f2bc4c7625be32c63caccfecc2723a2b9f78a7487a49c407"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum app_dirs2 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0aa02944d8a100b79057d1619032b1ad39de5eed6567cdeccbd53908b326e082"
 "checksum approx 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08abcc3b4e9339e33a3d0a5ed15d84a687350c05689d825e0f6655eef9e76a94"
+"checksum approx 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3c57ff1a5b00753647aebbbcf4ea67fa1e711a65ea7a30eb90dbf07de2485aee"
 "checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 "checksum autocfg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4e5f34df7a019573fb8bdc7e24a2bfebe51a2a1d6bfdbaeccedb3c41fc574727"
@@ -1483,94 +2158,143 @@ dependencies = [
 "checksum backtrace-sys 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "3fcce89e5ad5c8949caa9434501f7b55415b3e7ad5270cb88c75a8d35e8f1279"
 "checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
 "checksum bindgen 0.32.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8b242e11a8f446f5fc7b76b37e81d737cabca562a927bd33766dac55b5f1177f"
-"checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
+"checksum block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+"checksum bytecount 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b92204551573580e078dc80017f36a213eb77a0450e4ddd8cfa0f3f2d1f0178f"
 "checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
+"checksum bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "40ade3d27603c2cb345eb0912aec461a6dec7e06a4ae48589904e808335c7afa"
 "checksum bzip2 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "42b7c3cbf0fa9c1b82308d57191728ca0256cb821220f4e2fd410a72ade26e3b"
 "checksum bzip2-sys 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6584aa36f5ad4c9247f5323b0a42f37802b37a836f0ad87084d7a33961abe25f"
+"checksum cargo_metadata 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e5d1b4d380e1bab994591a24c2bdd1b054f64b60bef483a8c598c7c345bc3bbe"
 "checksum cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4a8b715cb4597106ea87c7c84b2f1d452c7492033765df7f32651e66fcf749"
 "checksum cexpr 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "42aac45e9567d97474a834efdee3081b3c942b2205be932092f53354ce503d6c"
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
+"checksum cgl 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "55e7ec0b74fe5897894cbc207092c577e87c52f8a59e8ca8d97ef37551f60a49"
 "checksum cgmath 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "87f025a17ad3f30d49015c787903976d5f9cd6115ece1eb7f4d6ffe06b8c4080"
 "checksum clang-sys 0.21.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e414af9726e1d11660801e73ccc7fb81803fb5f49e5903a25b348b2b3b480d2e"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum claxon 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "edfb6f5cce958c2741cae6774c8eb671c9caa8d079b6b7ab94d9fff895f6a3ac"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+"checksum cocoa 0.18.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cf79daa4e11e5def06e55306aa3601b87de6b5149671529318da048f67cdd77b"
 "checksum color_quant 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0dbbb57365263e881e805dc77d94697c9118fd94d8da011240555aa7b23445bd"
+"checksum core-foundation 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4e2640d6d0bf22e82bed1b73c6aef8d5dd31e5abe6666c57e6d45e2649f4f887"
 "checksum core-foundation-sys 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "716c271e8613ace48344f723b60b900a93150271e5be206212d052bbc0883efa"
+"checksum core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
+"checksum core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)" = "56790968ab1c8a1202a102e6de05fc6e1ec87da99e4e93e9a7d13efbfc1e95a9"
 "checksum coreaudio-rs 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f229761965dad3e9b11081668a6ea00f1def7aa46062321b5ec245b834f6e491"
 "checksum coreaudio-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "78fdbabf58d5b1f461e31b94a571c109284f384cec619a3d96e66ec55b4de82b"
 "checksum cpal 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d58ae1ed6536b1b233f5e3aeb6997a046ddb4d05e3f61701b58a92eb254a829e"
+"checksum crc32fast 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e91d5240c6975ef33aeb5f148f35275c25eda8e8a5f95abe421978b05b8bf192"
+"checksum crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f739f8c5363aca78cfb059edf753d8f0d36908c348f3d8d1503f03d8b75d9cf3"
+"checksum crossbeam-deque 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "05e44b8cf3e1a625844d1750e1f7820da46044ff6d28f4d43e455ba3e5bb2c13"
+"checksum crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "927121f5407de9956180ff5e936fe3cf4324279280001cd56b669d28ee7e9150"
+"checksum crossbeam-epoch 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f10a4f8f409aaac4b16a5474fb233624238fcdeefb9ba50d5ea059aab63ba31c"
+"checksum crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9"
+"checksum crossbeam-utils 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "41ee4864f4797060e52044376f7d107429ce1fb43460021b126424b7180ee21a"
 "checksum deflate 0.7.19 (registry+https://github.com/rust-lang/crates.io-index)" = "8a6abb26e16e8d419b5c78662aa9f82857c2386a073da266840e474d5055ec86"
 "checksum derivative 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6073e9676dbebdddeabaeb63e3b7cefd23c86f5c41d381ee1237cc77b1079898"
+"checksum dlib 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "77e51249a9d823a4cb79e3eca6dcd756153e8ed0157b6c04775d04bf1b13b76a"
+"checksum downcast-rs 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "18df8ce4470c189d18aa926022da57544f31e154631eb4cfe796aea97051fe6c"
 "checksum draw_state 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "33cf9537e2d06891448799b96d5a8c8083e0e90522a7fdabe6ebf4f41d79d651"
+"checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
 "checksum env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b"
 "checksum env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "afb070faf94c85d17d50ca44f6ad076bce18ae92f0037d350947240a36e9d42e"
-"checksum euclid 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c95fd0d455f114291a3109286bd387bd423770058474a2d3f38b712cd661df60"
+"checksum error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "07e791d3be96241c77c43846b665ef1384606da2cd2a48730abe606a12906e02"
+"checksum euclid 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d1a7698bdda3d7444a79d33bdc96e8b518d44ea3ff101d8492a6ca1207b886ea"
+"checksum euclid_macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fdcb84c18ea5037a1c5a23039b4ff29403abce2e0d6b1daa11cf0bde2b30be15"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
+"checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+"checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-"checksum generic-array 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fceb69994e330afed50c93524be68c42fa898c2d9fd4ee8da03bd7363acd26f2"
+"checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
+"checksum generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c0f28c2f5bfb5960175af447a2da7c18900693738343dc896ffbcabd9839592"
 "checksum gfx 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7d7ce0c1f747245342a73453fdb098ea0764c430421fbc4d98cdc8ef8ede4834"
 "checksum gfx_core 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c74932837e61f20956c3da1a47471513707dde300274812bba94373ab51830ae"
 "checksum gfx_device_gl 0.15.4 (registry+https://github.com/rust-lang/crates.io-index)" = "eb0cf0ff6a14427022856f608c167cd93ef01ead97ff2eff4ff0287130e80d0f"
 "checksum gfx_gl 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3e8a920f8f6c1025a7ddf9dd25502bf059506fd3cd765dfbe8dba0b56b7eeecb"
-"checksum gfx_glyph 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e5df0f26def7ce25e120c4c7e03b610fb479d44b984fcc19207ff8dff213c6a9"
-"checksum gfx_window_sdl 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f0d36e50e6620804c7613d1fd95f816b4f1c6e0ece0ccb8b155016a9404344f1"
-"checksum ggez 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "51c1ba59ec402c1fab55e59d9b715032a6c5e9385be3edf9628a128fad0af68a"
+"checksum gfx_window_glutin 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9762740a3aa4d2c0dc61fca23a4271e4c26586d90d7e904c00e2dd97d775db7f"
+"checksum ggez 0.5.0-rc.0 (git+https://github.com/ozkriff/ggez?rev=7699cb33b)" = "<none>"
 "checksum gif 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4bca55ac1f213920ce3527ccd62386f1f15fa3f1714aeee1cf93f2c416903f"
+"checksum gilrs 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a9096406afa56cc93a06d68e450a829d0bc2b21751f6b451f6c3e541db4316a0"
+"checksum gl_generator 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a0ffaf173cf76c73a73e080366bf556b4776ece104b06961766ff11449f38604"
 "checksum gl_generator 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a795170cbd85b5a7baa58d6d7525cae6a03e486859860c220f7ebbbdd379d0a"
+"checksum gleam 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "4b47f5b15742aee359c7895ab98cf2cceecc89bb4feb6f4e42f802d7899877da"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
+"checksum glutin 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "535c6eda58adbb227604b2db10a022ffd6339d7ea3e970f338e7d98aeb24fcc3"
+"checksum glyph_brush 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b8934457513381c7ecaa922e772b988b014b77acf2ce738ed005e670b40fa287"
+"checksum glyph_brush_layout 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3187ccf5eb60612a62fff8926bda17c576e5a695637a85dc08d213bc96e918f0"
+"checksum hashbrown 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "64b7d419d0622ae02fe5da6b9a5e1964b610a65bb37923b976aeebb6dbb8f86e"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hound 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8a164bb2ceaeff4f42542bdb847c41517c78a60f5649671b2a07312b6e117549"
 "checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
-"checksum image 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ebdff791af04e30089bde8ad2a632b86af433b40c04db8d70ad4b21487db7a6a"
+"checksum image 0.20.1 (registry+https://github.com/rust-lang/crates.io-index)" = "44665b4395d1844c96e7dc8ed5754782a1cdfd9ef458a80bbe45702681450504"
 "checksum inflate 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "84c683bde2d8413b8f1be3e459c30e4817672b6e7a31d9212b0323154e76eba7"
+"checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
+"checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum jpeg-decoder 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "c8b7d43206b34b3f94ea9445174bda196e772049b9bddbc620c9d29b2d20110d"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum khronos_api 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "037ab472c33f67b5fbd3e9163a2645319e5356fcd355efa6d4eb7fff4bbcb554"
-"checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
+"checksum khronos_api 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "62237e6d326bd5871cd21469323bf096de81f1618cd82cbaf5d87825335aeb49"
 "checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
-"checksum lewton 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c1b7b81410f7895d4793bae921cc62317c5500c6ef211c9c24cad778eda77c20"
+"checksum lewton 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "81d583f12101d36b9c19f85326f3c4e7d3b88d17f1131113e13da056dc0d4437"
 "checksum libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)" = "2d2857ec59fadc0773853c664d2d18e7198e83883e7060b63c924cb077bd5c74"
 "checksum libloading 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fd38073de8f7965d0c17d30546d4bb6da311ab428d1c7a3fc71dff7f9d4979b9"
+"checksum libloading 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3ad660d7cb8c5822cd83d10897b0f1f1526792737a179e73896152f85b88c2"
+"checksum libm 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "03c0bb6d5ce1b5cc6fd0578ec1cbc18c9d88b5b591a5c7c1d6c6175e266a0819"
+"checksum libudev-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
+"checksum line_drawing 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5cc7ad3d82c845bdb5dde34ffdcc7a5fb4d2996e1e1ee0f19c33bc80e15196b9"
 "checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
+"checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
-"checksum lyon 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aefaafb69dc360deaeb1a645b11eedd25b45047dd46d5adb5775349e051e7a6c"
-"checksum lyon_geom 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1470fc1e16d6c3b2e86fb2b9abeb6984badcecddb9a3852c750bd0b35e83316f"
-"checksum lyon_path 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "932fd3b7e8d2808f1833ddb753be4158107ffd9b7348f0e76c3ef5eb5d984da5"
-"checksum lyon_tessellation 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cc4db444ab87e187c29286f0f2aab6e93380f0e6ae064a2140078698b3d924a7"
+"checksum lyon 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d68ea35821a442a2994ea0b0344dacc4c7937890abc009db543d39a18c17be8d"
+"checksum lyon_algorithms 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e9e7102c3aebfca26b0e4654a9ef512dc04d8407c339dba5bd5ff8034b3945f1"
+"checksum lyon_geom 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2b60eaa9061c87affcd671e88289ce6971324269ec6548b677e02624ef3ef63c"
+"checksum lyon_path 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d8415c7026f0112a1981b9cf3ae7f1f9de78a278e60782d63d168016318507e9"
+"checksum lyon_tessellation 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94c64797d4d9c0b895422325cab6b5fa4710dfc7e4eb3fe74ecd55ae92964f36"
 "checksum lzw 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7d947cbb889ed21c2a84be6ffbaebf5b4e0f4340638cba0444907e38b56be084"
-"checksum matrixmultiply 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "dcad67dcec2d58ff56f6292582377e6921afdf3bfbd533e26fb8900ae575e002"
+"checksum mach 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "86dd2487cdfea56def77b88438a2c915fb45113c5319bfe7e14306ca4cd0b0e1"
+"checksum malloc_buf 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+"checksum matrixmultiply 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dcfed72d871629daa12b25af198f110e8095d7650f5f4c61c5bac28364604f9b"
 "checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
 "checksum memchr 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "db4c41318937f6e76648f42826b1d9ade5c09cafb5aef7e351240a70f39206e9"
-"checksum msdos_time 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "aad9dfe950c057b1bfe9c1f2aa51583a8468ef2a5baba2ebbe06d775efeb7729"
-"checksum nalgebra 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3f73409a1a0876d9d7be16a7fb8fd7e0658df54098210c93a17d2d5e8ca7afe4"
+"checksum memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
+"checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
+"checksum minimp3 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f41696ddc46df17ef8e42f145baa2805b1e048c59d2321292acfe4a1daa58244"
+"checksum minimp3-sys 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c109ae05c00ad6e3a53fab101e2f234545bdd010f0fffd399355efaf70817817"
+"checksum mint 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c9e6c29b4bb0155117ea1a61520406c975673ee71b0287323f06d1a8d69c4a7c"
+"checksum nalgebra 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f75ff2a99063281e23bc062bed0144a9c1f627f4ac00b060b378276d7cff1d83"
+"checksum nix 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b7fd5681d13fda646462cfbd4e5f2051279a89a544d50eb98c365b507246839f"
+"checksum nix 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "921f61dc817b379d0834e45d5ec45beaacfae97082090a49c2cf30dcbc30206f"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum nom 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05aec50c70fd288702bcd93284a8444607f3292dbdf2a30de5ea5dcdbe72287b"
-"checksum num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
 "checksum num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cf4825417e1e1406b3782a8ce92f4d53f26ec055e3622e1881ca8e9f5f9e08db"
-"checksum num-complex 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "b288631d7878aaf59442cffd36910ea604ecd7745c36054328595114001c9656"
 "checksum num-complex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "107b9be86cd2481930688277b675b0114578227f034674726605b8a482d8baf8"
 "checksum num-derive 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8af1847c907c2f04d7bfd572fb25bbb4385c637fe5be163cf2f8c5d778fe1e7d"
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
 "checksum num-iter 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "af3fdbbc3291a5464dc57b03860ec37ca6bf915ed6ee385e7c6c052c422b2124"
-"checksum num-rational 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "ee314c74bd753fc86b4780aa9475da469155f3848473a261d2d18e35245a784e"
 "checksum num-rational 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4e96f040177bb3da242b5b1ecf3f54b5d5af3efbbfb18608977a5d2767b22f10"
 "checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
-"checksum ogg 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "013b78ceb7fb82555a2f8a95d8e40866fe64a5d15b83c51b3e1fdd40cd903ed3"
+"checksum num_cpus 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5a69d464bdc213aaaff628444e99578ede64e9c854025aa43b9796530afa9238"
+"checksum objc 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "9833ab0efe5361b1e2122a0544a5d3359576911a42cb098c2e59be8650807367"
+"checksum ogg 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d79f1db9148be9d0e174bb3ac890f6030fcb1ed947267c5a91ee4c91b5a91e15"
 "checksum ole32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d2c49021782e5233cd243168edfa8037574afed4eba4bbaf538b3d8d1789d8c"
-"checksum ordered-float 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7eb5259643245d3f292c7a146b2df53bba24d7eab159410e648eb73dc164669d"
+"checksum ordered-float 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2f0015e9e8e28ee20c581cfbfe47c650cedeb9ed0721090e0b7ebb10b9cdbcc2"
+"checksum osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "88cfece6e95d2e717e0872a7f53a8684712ad13822a7979bc760b9c77ec0013b"
+"checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
+"checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
+"checksum parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9"
 "checksum peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+"checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum png 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f54b9600d584d3b8a739e1662a595fab051329eff43f20e7d8cc22872962145b"
 "checksum podio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "780fb4b6698bbf9cf2444ea5d22411cef2953f0824b98f33cf454ec5615645bd"
 "checksum proc-macro2 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cd07deb3c6d1d9ff827999c7f9b04cdfd66b1b17ae508e14fe47b620f2282ae0"
 "checksum proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)" = "77619697826f31a02ae974457af0b29b723e5619e113e9397b8b82c6bd253f09"
+"checksum pulldown-cmark 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eef52fac62d0ea7b9b4dc7da092aa64ea7ec3d90af6679422d3d7e0e14b6ee15"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
-"checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum quote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1eca14c727ad12702eb4b6bfb5a232287dcf8385cb8ca83a3eeaf6519c44c408"
 "checksum quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "53fa22a1994bd0f9372d7a816207d8a2677ad0325b073f5c5332760f0fb62b5c"
 "checksum rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "15a732abf9d20f0ad8eeb6f909bf6868722d9a06e1e50802b6a70351f40b4eb1"
@@ -1583,54 +2307,71 @@ dependencies = [
 "checksum rand_pcg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "086bd09a33c7044e56bb44d5bdde5a60e7f119a9e95b0775f545de759a32fe05"
 "checksum rand_xorshift 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "effa3fcaa47e18db002bdde6060944b6d2f9cfd8db471c30e873448ad9187be3"
 "checksum rawpointer 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ebac11a9d2e11f2af219b8b8d833b76b1ea0e054aa0e8d8e9e4cbde353bdf019"
+"checksum rayon 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "373814f27745b2686b350dd261bfd24576a6fb0e2c5919b3a2b6005f820b0473"
+"checksum rayon-core 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b055d1e92aba6877574d8fe604a63c8b5df60f60e5982bf7ccbb1338ea527356"
 "checksum redox_syscall 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)" = "a84bcd297b87a545980a2d25a0beb72a1f490c31f0a9fde52fca35bfbb1ceb70"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
 "checksum regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37e7cbbd370869ce2e8dff25c7018702d10b21a20ef7135316f8daecd6c25b7f"
 "checksum regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
 "checksum regex-syntax 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4e47a2ed29da7a9e1960e1639e7a982e6edc6d49be308a3b02daf511504a16d1"
-"checksum rodio 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1e2767a246f9b284ec568e45e17ed3e6c52a91a3d42fa11ba00466b6ea5a6b55"
+"checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
+"checksum rodio 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "10cb47941163cb747978d13a5c1b5c8fcd17f501817c4b77b9d69aed9ea240bc"
 "checksum ron 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c48677d8a9247a4e0d1f3f9cb4b0a8e29167fdc3c04f383a5e669cd7a960ae0f"
 "checksum rustc-demangle 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "01b90379b8664dd83460d59bdc5dd1fd3172b8913788db483ed1325171eab2f7"
+"checksum rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7540fc8b0c49f096ee9c961cda096467dce8084bec6bdca2fc83895fd9b28cb8"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-"checksum rusttype 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4667e40922320e08b358ce9cfc7d08cc37a827f223c0e113b5dee573143a534d"
+"checksum rusttype 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "436c67ae0d0d24f14e1177c3ed96780ee16db82b405f0fba1bb80b46c9a30625"
+"checksum ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "eb9e9b8cde282a9fe6a42dd4681319bfb63f121b8a8ee9439c6f4107e58a46f7"
 "checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"
-"checksum sdl2 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a74c2a98a354b20713b90cce70aef9e927e46110d1bc4ef728fd74e0d53eba60"
-"checksum sdl2-sys 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5c543ce8a6e33a30cb909612eeeb22e693848211a84558d5a00bb11e791b7ab7"
+"checksum same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8f20c4be53a8a1ff4c1f1b2bd14570d2f634628709752f0702ecdd2b3f9a5267"
+"checksum scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
+"checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
+"checksum seahash 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e048636bed25842fcdc36e5ad1ec6295b72d4b5b8a4b759b64915a4ce2b9d09d"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)" = "6fa52f19aee12441d5ad11c9a00459122bd8f98707cadf9778c540674f1935b6"
 "checksum serde_derive 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)" = "96a7f9496ac65a2db5929afa087b54f8fc5008dcfbe48a8874ed20049b0d6154"
+"checksum serde_json 1.0.34 (registry+https://github.com/rust-lang/crates.io-index)" = "bdf540260cfee6da923831f4776ddc495ada940c30117977c70f1313a6130545"
+"checksum shared_library 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
 "checksum shell32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9ee04b46101f57121c9da2b151988283b6beb79b34f5bb29a58ee48cb695122c"
 "checksum sid 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "29e0a6006cf04d568a49363baca3dabddbbe46538f7c76692d405f5f5d140ecd"
-"checksum smart-default 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3e7392ae8cdf79428cc98170bf264af7219887def8a30bb61d7ad2200313e88d"
+"checksum skeptic 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6fb8ed853fdc19ce09752d63f3a2e5b5158aeb261520cd75eb618bd60305165"
+"checksum slice-deque 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "d39fca478d10e201944a8e21f4393d6bfe38fa3b16a152050e4d097fe2bbf494"
+"checksum smallvec 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b73ea3738b47563803ef814925e69be00799a8c07420be8b996f8e98fb2336db"
+"checksum smart-default 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "70e5c02ddada494809d36623d38050f3bd63446750abd21e7e13c01aa3a79b69"
+"checksum smithay-client-toolkit 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d858330eeed4efaf71c560555e2a6a0597d01b7d52685c3cc964ab1cc360f8c6"
+"checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum stb_truetype 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "71a7d260b43b6129a22dc341be18a231044ca67a48b7e32625f380cc5ec9ad70"
 "checksum stdweb 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ef5430c8e36b713e13b48a9f709cc21e046723fe44ce34587b73a830203b533e"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum structopt 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "670ad348dc73012fcf78c71f06f9d942232cdd4c859d4b6975e27836c3efc0c3"
 "checksum structopt-derive 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "ef98172b1a00b0bec738508d3726540edcbd186d50dfd326f2b1febbb3559f04"
-"checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum syn 0.15.23 (registry+https://github.com/rust-lang/crates.io-index)" = "9545a6a093a3f0bd59adb472700acc08cad3776f860f16a897dfce8c88721cbc"
-"checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
+"checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 "checksum termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
-"checksum time 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "847da467bf0db05882a9e2375934a8a55cffdc9db0d128af1518200260ba1f6c"
+"checksum tiff 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a2cc6c4fd13cb1cfd20abdb196e794ceccb29371855b7e7f575945f920a5b3c2"
 "checksum toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
-"checksum twox-hash 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "555cd4909480122bbbf21e34faac4cb08a171f324775670447ed116726c474af"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 "checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
-"checksum unicode-normalization 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6a0180bc61fc5a987082bfa111f4cc95c4caff7f9799f3e46df09163a937aa25"
 "checksum unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "aa6024fc12ddfd1c6dbc14a80fa2324d4568849869b779f6bd37e5e4c03344d1"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
-"checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
+"checksum uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e1436e58182935dcd9ce0add9ea0b558e8a87befe01c1a301e6020aeb0876363"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+"checksum walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d9d7ed3431229a144296213105a390676cc49c9b6a72bd19f3176c98e129fa1"
+"checksum wayland-client 0.21.10 (registry+https://github.com/rust-lang/crates.io-index)" = "cb4e519a7a979ddf97ee25c07830bd10b2c466b3b904b8ad4a05b4eee58c1a4e"
+"checksum wayland-commons 0.21.10 (registry+https://github.com/rust-lang/crates.io-index)" = "d985937818df10af90fe61bf8fc520fc6179539d972378b78be773694bb9f432"
+"checksum wayland-protocols 0.21.10 (registry+https://github.com/rust-lang/crates.io-index)" = "e634e68e5b759cb549410ae1f25aab3c77cdc8f861aed9d0e86c2bd74efcb086"
+"checksum wayland-scanner 0.21.10 (registry+https://github.com/rust-lang/crates.io-index)" = "1c8b867a824057b856790776e7cee37daf0435fc06543f2d96b2e37d15322e99"
+"checksum wayland-sys 0.21.10 (registry+https://github.com/rust-lang/crates.io-index)" = "6807f24ccb5b1a76a854fbd18160ae11cea64717b2f643d10810e5ef7fba2f59"
 "checksum which 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e84a603e7e0b1ce1aa1ee2b109c7be00155ce52df5081590d1ffb93f4f515cb2"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
@@ -1639,7 +2380,10 @@ dependencies = [
 "checksum winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "afc5508759c5bf4285e61feb862b6083c8480aec864fa17a81fdec6f69b461ab"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum wincolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "561ed901ae465d6185fa7864d63fbd5720d0ef718366c9a4dc83cf6170d7e9ba"
+"checksum winit 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c57c15bd4c0ef18dff33e263e452abe32d00e2e05771cacaa410a14cc1c0776"
+"checksum x11-dl 2.18.3 (registry+https://github.com/rust-lang/crates.io-index)" = "940586acb859ea05c53971ac231685799a7ec1dee66ac0bccc0e6ad96e06b4e3"
 "checksum xdg 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d089681aa106a86fade1b0128fb5daf07d5867a509ab036d99988dec80429a57"
 "checksum xi-unicode 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "12ea8eda4b1eb72f02d148402e23832d56a33f55d8c1b2d5bcdde91d79d47cb1"
 "checksum xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c1cb601d29fe2c2ac60a2b2e5e293994d87a1f6fa9687a31a15270f909be9c2"
-"checksum zip 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "77ce0ceee93c995954a31f77903925a6a8bb094709445238e344f2107910e29e"
+"checksum xml-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "541b12c998c5b56aa2b4e6f18f03664eef9a4fd0a246a55594efae6cc2d964b5"
+"checksum zip 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "00acf1fafb786ff450b6726e5be41ef029142597b47a40ce80f952f1471730a0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,8 @@ description = "A 2D turn-based hexagonal tactical game."
 members = ["zcomponents", "ggwp-zgui", "ggwp-zscene"]
 
 [dependencies]
-ggez = "0.4"
+# ggez = "0.5.0-rc.0" # TODO: get back to crates.io version
+ggez = { git = "https://github.com/ozkriff/ggez", rev = "7699cb33b" }
 ron = "0.4"
 rand = "0.6"
 log = "0.4"

--- a/README.md
+++ b/README.md
@@ -48,13 +48,6 @@ Precompiled binaries for Linux, Windows and macOS:
 
 ## Building from Source
 
-As Zemeroth uses [ggez] game engine,
-you need to have the SDL2 libraries installed on your system.
-The best way to do this is documented [by the SDL2 crate][install sdl2].
-
-[ggez]: https://github.com/ggez/ggez
-[install sdl2]: https://github.com/AngryLawyer/rust-sdl2#user-content-requirements
-
 ```bash
 # Clone this repo
 git clone https://github.com/ozkriff/zemeroth
@@ -81,6 +74,7 @@ This repo contains a bunch of helper crates:
 - [ggwp-zgui] is a simple and opinionated ggez-based GUI library
 - [ggwp-zscene] is a simple scene and declarative animation manager
 
+[ggez]: https://github.com/ggez/ggez
 [zcomponents]: ./zcomponents
 [ggwp-zscene]: ./ggwp-zscene
 [ggwp-zgui]: ./ggwp-zgui

--- a/ggwp-zgui/Cargo.toml
+++ b/ggwp-zgui/Cargo.toml
@@ -8,5 +8,6 @@ description = "Tiny and opionated GUI library"
 keywords = ["ggez", "gamedev", "gui"]
 
 [dependencies]
-ggez = "0.4"
+# ggez = "0.5.0-rc.0" # TODO: get back to crates.io version
+ggez = { git = "https://github.com/ozkriff/ggez", rev = "7699cb33b" }
 log = "0.4"

--- a/ggwp-zgui/examples/absolute_coordinates.rs
+++ b/ggwp-zgui/examples/absolute_coordinates.rs
@@ -1,6 +1,7 @@
 use ggez::{
     conf, event,
-    graphics::{self, Font, Point2, Rect, Text},
+    graphics::{self, Font, Rect, Text},
+    nalgebra::Point2,
     Context, ContextBuilder, GameResult,
 };
 use ggwp_zgui as ui;
@@ -11,12 +12,12 @@ enum Message {
     Command2,
 }
 
-fn make_gui(context: &mut Context, font: &Font) -> GameResult<ui::Gui<Message>> {
+fn make_gui(context: &mut Context, font: Font) -> GameResult<ui::Gui<Message>> {
     let mut gui = ui::Gui::new(context);
-    let image_1 = Text::new(context, "[Button1]", font)?.into_inner();
-    let image_2 = Text::new(context, "[Button2]", font)?.into_inner();
-    let button_1 = ui::Button::new(context, image_1, 0.2, gui.sender(), Message::Command1);
-    let button_2 = ui::Button::new(context, image_2, 0.2, gui.sender(), Message::Command2);
+    let text_1 = Box::new(Text::new(("[Button1]", font, 32.0)));
+    let text_2 = Box::new(Text::new(("[Button1]", font, 64.0)));
+    let button_1 = ui::Button::new(context, text_1, 0.2, gui.sender(), Message::Command1);
+    let button_2 = ui::Button::new(context, text_2, 0.2, gui.sender(), Message::Command2);
     let mut layout = ui::VLayout::new();
     layout.add(Box::new(button_1));
     layout.add(Box::new(button_2));
@@ -31,72 +32,81 @@ struct State {
 
 impl State {
     fn new(context: &mut Context) -> GameResult<State> {
-        let (w, h) = graphics::get_drawable_size(context);
-        let font = graphics::Font::new(context, "/Karla-Regular.ttf", 32)?;
-        let gui = make_gui(context, &font)?;
+        let (w, h) = graphics::drawable_size(context);
+        let font = Font::new(context, "/Karla-Regular.ttf")?;
+        let gui = make_gui(context, font)?;
         let mut this = State { gui };
-        this.resize(context, w, h);
+        this.resize(context, w as _, h as _)?;
         Ok(this)
     }
 
-    fn resize(&mut self, context: &mut Context, w: u32, h: u32) {
-        let aspect_ratio = w as f32 / h as f32;
+    fn resize(&mut self, context: &mut Context, w: f32, h: f32) -> GameResult {
+        let aspect_ratio = w / h;
         let coordinates = Rect::new(-aspect_ratio, -1.0, aspect_ratio * 2.0, 2.0);
-        graphics::set_screen_coordinates(context, coordinates).unwrap();
+        graphics::set_screen_coordinates(context, coordinates)?;
         self.gui.resize(aspect_ratio);
+        Ok(())
     }
 
-    fn draw_scene(&self, context: &mut Context) -> GameResult<()> {
-        let pos = Point2::new(0.0, 0.0);
-        let mode = ggez::graphics::DrawMode::Fill;
-        graphics::circle(context, mode, pos, 0.4, 0.01)?;
+    fn draw_scene(&self, context: &mut Context) -> GameResult {
+        let circle = {
+            let mode = graphics::DrawMode::fill();
+            let pos = [0.0, 0.0];
+            let radius = 0.4;
+            let tolerance = 0.001;
+            let color = [0.5, 0.5, 0.5, 1.0].into();
+            graphics::Mesh::new_circle(context, mode, pos, radius, tolerance, color)?
+        };
+        let param = graphics::DrawParam::new();
+        graphics::draw(context, &circle, param)?;
         Ok(())
     }
 }
 
 impl event::EventHandler for State {
-    fn update(&mut self, _: &mut Context) -> GameResult<()> {
+    fn update(&mut self, _: &mut Context) -> GameResult {
         Ok(())
     }
 
-    fn draw(&mut self, context: &mut Context) -> GameResult<()> {
-        graphics::set_background_color(context, [1.0, 1.0, 1.0, 1.0].into());
-        graphics::clear(context);
+    fn draw(&mut self, context: &mut Context) -> GameResult {
+        let bg_color = [1.0, 1.0, 1.0, 1.0].into();
+        graphics::clear(context, bg_color);
         self.draw_scene(context)?;
         self.gui.draw(context)?;
-        graphics::present(context);
-        Ok(())
+        graphics::present(context)
     }
 
-    fn resize_event(&mut self, context: &mut Context, w: u32, h: u32) {
-        self.resize(context, w, h);
+    fn resize_event(&mut self, context: &mut Context, w: f32, h: f32) {
+        self.resize(context, w, h).expect("Can't resize the window");
     }
 
     fn mouse_button_up_event(
         &mut self,
         context: &mut Context,
-        _: ggez::event::MouseButton,
-        x: i32,
-        y: i32,
+        _: event::MouseButton,
+        x: f32,
+        y: f32,
     ) {
-        let window_pos = Point2::new(x as _, y as _);
+        let window_pos = Point2::new(x, y);
         let pos = ui::window_to_screen(context, window_pos);
         let message = self.gui.click(pos);
         println!("[{},{}] -> {}: {:?}", x, y, pos, message);
     }
 }
 
-fn context() -> GameResult<ggez::Context> {
-    let name = "ggwp_zgui example absolute_coordinates";
-    let window_conf = conf::WindowSetup::default().resizable(true).title(name);
+fn context() -> GameResult<(Context, event::EventsLoop)> {
+    let name = file!();
+    let window_conf = conf::WindowSetup::default().title(name);
+    let window_mode = conf::WindowMode::default().resizable(true);
     ContextBuilder::new(name, "ozkriff")
         .window_setup(window_conf)
+        .window_mode(window_mode)
         .add_resource_path("resources")
         .build()
 }
 
-fn main() -> GameResult<()> {
-    let mut context = context()?;
+fn main() -> GameResult {
+    let (mut context, mut events_loop) = context()?;
     let mut state = State::new(&mut context)?;
-    event::run(&mut context, &mut state)
+    event::run(&mut context, &mut events_loop, &mut state)
 }

--- a/ggwp-zgui/examples/layout.rs
+++ b/ggwp-zgui/examples/layout.rs
@@ -1,6 +1,7 @@
 use ggez::{
     conf, event,
-    graphics::{self, Font, Point2, Text},
+    graphics::{self, Font, Text},
+    nalgebra::Point2,
     Context, ContextBuilder, GameResult,
 };
 use ggwp_zgui as ui;
@@ -11,12 +12,13 @@ enum Message {
     Command2,
 }
 
-fn make_gui(context: &mut Context, font: &Font) -> GameResult<ui::Gui<Message>> {
+fn make_gui(context: &mut Context, font: Font) -> GameResult<ui::Gui<Message>> {
+    let font_size = 64.0;
     let mut gui = ui::Gui::new(context);
-    let image_1 = Text::new(context, "[Button1]", font)?.into_inner();
-    let image_2 = Text::new(context, "[Button2]", font)?.into_inner();
-    let button_1 = ui::Button::new(context, image_1, 0.2, gui.sender(), Message::Command1);
-    let button_2 = ui::Button::new(context, image_2, 0.2, gui.sender(), Message::Command2);
+    let text_1 = Box::new(Text::new(("[Button1]", font, font_size)));
+    let text_2 = Box::new(Text::new(("[Button2]", font, font_size)));
+    let button_1 = ui::Button::new(context, text_1, 0.2, gui.sender(), Message::Command1);
+    let button_2 = ui::Button::new(context, text_2, 0.2, gui.sender(), Message::Command2);
     let mut layout = ui::VLayout::new();
     layout.add(Box::new(button_1));
     layout.add(Box::new(button_2));
@@ -31,31 +33,30 @@ struct State {
 
 impl State {
     fn new(context: &mut Context) -> GameResult<State> {
-        let font = Font::new(context, "/Karla-Regular.ttf", 32)?;
-        let gui = make_gui(context, &font)?;
+        let font = Font::new(context, "/Karla-Regular.ttf")?;
+        let gui = make_gui(context, font)?;
         Ok(Self { gui })
     }
 
-    fn resize(&mut self, _: &mut Context, w: u32, h: u32) {
-        let aspect_ratio = w as f32 / h as f32;
+    fn resize(&mut self, _: &mut Context, w: f32, h: f32) {
+        let aspect_ratio = w / h;
         self.gui.resize(aspect_ratio);
     }
 }
 
 impl event::EventHandler for State {
-    fn update(&mut self, _: &mut Context) -> GameResult<()> {
+    fn update(&mut self, _: &mut Context) -> GameResult {
         Ok(())
     }
 
-    fn draw(&mut self, context: &mut Context) -> GameResult<()> {
-        graphics::set_background_color(context, [1.0, 1.0, 1.0, 1.0].into());
-        graphics::clear(context);
+    fn draw(&mut self, context: &mut Context) -> GameResult {
+        let bg_color = [1.0, 1.0, 1.0, 1.0].into();
+        graphics::clear(context, bg_color);
         self.gui.draw(context)?;
-        graphics::present(context);
-        Ok(())
+        graphics::present(context)
     }
 
-    fn resize_event(&mut self, context: &mut Context, w: u32, h: u32) {
+    fn resize_event(&mut self, context: &mut Context, w: f32, h: f32) {
         self.resize(context, w, h);
     }
 
@@ -63,27 +64,29 @@ impl event::EventHandler for State {
         &mut self,
         context: &mut Context,
         _: ggez::event::MouseButton,
-        x: i32,
-        y: i32,
+        x: f32,
+        y: f32,
     ) {
-        let window_pos = Point2::new(x as _, y as _);
+        let window_pos = Point2::new(x, y);
         let pos = ui::window_to_screen(context, window_pos);
         let message = self.gui.click(pos);
         println!("[{},{}] -> {}: {:?}", x, y, pos, message);
     }
 }
 
-fn context() -> GameResult<ggez::Context> {
-    let name = "ggwp_zgui example layout";
-    let window_conf = conf::WindowSetup::default().resizable(true).title(name);
+fn context() -> GameResult<(Context, event::EventsLoop)> {
+    let name = file!();
+    let window_conf = conf::WindowSetup::default().title(name);
+    let window_mode = conf::WindowMode::default().resizable(true);
     ContextBuilder::new(name, "ozkriff")
         .window_setup(window_conf)
+        .window_mode(window_mode)
         .add_resource_path("resources")
         .build()
 }
 
-fn main() -> GameResult<()> {
-    let mut context = context()?;
+fn main() -> GameResult {
+    let (mut context, mut events_loop) = context()?;
     let mut state = State::new(&mut context)?;
-    event::run(&mut context, &mut state)
+    event::run(&mut context, &mut events_loop, &mut state)
 }

--- a/ggwp-zgui/examples/pixel_coordinates.rs
+++ b/ggwp-zgui/examples/pixel_coordinates.rs
@@ -1,6 +1,7 @@
 use ggez::{
     conf, event,
-    graphics::{self, Font, Point2, Text},
+    graphics::{self, Font, Text},
+    nalgebra::Point2,
     Context, ContextBuilder, GameResult,
 };
 use ggwp_zgui as ui;
@@ -11,12 +12,12 @@ enum Message {
     Command2,
 }
 
-fn make_gui(context: &mut Context, font: &Font) -> GameResult<ui::Gui<Message>> {
+fn make_gui(context: &mut Context, font: Font) -> GameResult<ui::Gui<Message>> {
     let mut gui = ui::Gui::new(context);
-    let image_1 = Text::new(context, "[Button1]", font)?.into_inner();
-    let image_2 = Text::new(context, "[Button2]", font)?.into_inner();
-    let button_1 = ui::Button::new(context, image_1, 0.2, gui.sender(), Message::Command1);
-    let button_2 = ui::Button::new(context, image_2, 0.2, gui.sender(), Message::Command2);
+    let text_1 = Box::new(Text::new(("[Button1]", font, 32.0)));
+    let text_2 = Box::new(Text::new(("[Button1]", font, 64.0)));
+    let button_1 = ui::Button::new(context, text_1, 0.2, gui.sender(), Message::Command1);
+    let button_2 = ui::Button::new(context, text_2, 0.2, gui.sender(), Message::Command2);
     let mut layout = ui::VLayout::new();
     layout.add(Box::new(button_1));
     layout.add(Box::new(button_2));
@@ -31,73 +32,81 @@ struct State {
 
 impl State {
     fn new(context: &mut Context) -> GameResult<State> {
-        let (w, h) = graphics::get_drawable_size(context);
-        let font = graphics::Font::new(context, "/Karla-Regular.ttf", 32)?;
-        let gui = make_gui(context, &font)?;
+        let (w, h) = graphics::drawable_size(context);
+        let font = Font::new(context, "/Karla-Regular.ttf")?;
+        let gui = make_gui(context, font)?;
         let mut this = State { gui };
-        this.resize(context, w, h)?;
+        this.resize(context, w as _, h as _)?;
         Ok(this)
     }
 
-    fn resize(&mut self, context: &mut Context, w: u32, h: u32) -> GameResult<()> {
-        let aspect_ratio = w as f32 / h as f32;
+    fn resize(&mut self, context: &mut Context, w: f32, h: f32) -> GameResult {
+        let aspect_ratio = w / h;
         self.gui.resize(aspect_ratio);
-        let rect = graphics::Rect::new(0.0, 0.0, w as f32, h as f32);
+        let rect = graphics::Rect::new(0.0, 0.0, w, h);
         graphics::set_screen_coordinates(context, rect)?;
         Ok(())
     }
 
-    fn draw_scene(&self, context: &mut Context) -> GameResult<()> {
-        let pos = Point2::new(150.0, 150.0);
-        graphics::circle(context, ggez::graphics::DrawMode::Fill, pos, 100.0, 2.0)?;
-        self.gui.draw(context)?;
+    fn draw_scene(&self, context: &mut Context) -> GameResult {
+        let circle = {
+            let mode = graphics::DrawMode::fill();
+            let pos = Point2::new(150.0, 150.0);
+            let radius = 100.0;
+            let tolerance = 2.0;
+            let color = [0.5, 0.5, 0.5, 1.0].into();
+            graphics::Mesh::new_circle(context, mode, pos, radius, tolerance, color)?
+        };
+        let param = graphics::DrawParam::new();
+        graphics::draw(context, &circle, param)?;
         Ok(())
     }
 }
 
 impl event::EventHandler for State {
-    fn update(&mut self, _: &mut Context) -> GameResult<()> {
+    fn update(&mut self, _: &mut Context) -> GameResult {
         Ok(())
     }
 
-    fn draw(&mut self, context: &mut Context) -> GameResult<()> {
-        graphics::set_background_color(context, [1.0, 1.0, 1.0, 1.0].into());
-        graphics::clear(context);
+    fn draw(&mut self, context: &mut Context) -> GameResult {
+        let bg_color = [1.0, 1.0, 1.0, 1.0].into();
+        graphics::clear(context, bg_color);
         self.draw_scene(context)?;
         self.gui.draw(context)?;
-        graphics::present(context);
-        Ok(())
+        graphics::present(context)
     }
 
-    fn resize_event(&mut self, context: &mut Context, w: u32, h: u32) {
+    fn resize_event(&mut self, context: &mut Context, w: f32, h: f32) {
         self.resize(context, w, h).expect("Can't resize the window");
     }
 
     fn mouse_button_up_event(
         &mut self,
         context: &mut Context,
-        _: ggez::event::MouseButton,
-        x: i32,
-        y: i32,
+        _: event::MouseButton,
+        x: f32,
+        y: f32,
     ) {
-        let window_pos = Point2::new(x as _, y as _);
+        let window_pos = Point2::new(x, y);
         let pos = ui::window_to_screen(context, window_pos);
         let message = self.gui.click(pos);
         println!("[{},{}] -> {}: {:?}", x, y, pos, message);
     }
 }
 
-fn context() -> GameResult<ggez::Context> {
-    let name = "ggwp_zgui example pixel_coordinates";
-    let window_conf = conf::WindowSetup::default().resizable(true).title(name);
+fn context() -> GameResult<(Context, event::EventsLoop)> {
+    let name = file!();
+    let window_conf = conf::WindowSetup::default().title(name);
+    let window_mode = conf::WindowMode::default().resizable(true);
     ContextBuilder::new(name, "ozkriff")
         .window_setup(window_conf)
+        .window_mode(window_mode)
         .add_resource_path("resources")
         .build()
 }
 
-fn main() -> GameResult<()> {
-    let mut context = context()?;
+fn main() -> GameResult {
+    let (mut context, mut events_loop) = context()?;
     let mut state = State::new(&mut context)?;
-    event::run(&mut context, &mut state)
+    event::run(&mut context, &mut events_loop, &mut state)
 }

--- a/ggwp-zgui/examples/remove.rs
+++ b/ggwp-zgui/examples/remove.rs
@@ -1,6 +1,7 @@
 use ggez::{
     conf, event,
-    graphics::{self, Font, Image, Point2, Text},
+    graphics::{self, Font, Image, Text},
+    nalgebra::Point2,
     Context, ContextBuilder, GameResult,
 };
 use ggwp_zgui as ui;
@@ -12,14 +13,15 @@ enum Message {
 
 fn make_label(context: &mut Context) -> ui::RcWidget {
     let image = Image::new(context, "/fire.png").expect("Can't load test image");
-    ui::pack(ui::Label::new(context, image, 0.5))
+    ui::pack(ui::Label::new(context, Box::new(image), 0.5))
 }
 
-fn make_gui(context: &mut Context, font: &Font) -> GameResult<ui::Gui<Message>> {
+fn make_gui(context: &mut Context, font: Font) -> GameResult<ui::Gui<Message>> {
+    let font_size = 32.0;
     let mut gui = ui::Gui::new(context);
     let anchor = ui::Anchor(ui::HAnchor::Right, ui::VAnchor::Bottom);
-    let image = Text::new(context, "[Add/Remove]", &font)?.into_inner();
-    let button = ui::Button::new(context, image, 0.2, gui.sender(), Message::AddOrRemove);
+    let text = Box::new(Text::new(("[Add/Remove]", font, font_size)));
+    let button = ui::Button::new(context, text, 0.2, gui.sender(), Message::AddOrRemove);
     gui.add(&ui::pack(button), anchor);
     Ok(gui)
 }
@@ -31,13 +33,13 @@ struct State {
 
 impl State {
     fn new(context: &mut Context) -> GameResult<State> {
-        let font = graphics::Font::new(context, "/Karla-Regular.ttf", 32)?;
-        let gui = make_gui(context, &font)?;
+        let font = Font::new(context, "/Karla-Regular.ttf")?;
+        let gui = make_gui(context, font)?;
         Ok(Self { gui, label: None })
     }
 
-    fn resize(&mut self, _: &mut Context, w: u32, h: u32) {
-        let aspect_ratio = w as f32 / h as f32;
+    fn resize(&mut self, _: &mut Context, w: f32, h: f32) {
+        let aspect_ratio = w / h;
         self.gui.resize(aspect_ratio);
     }
 
@@ -66,14 +68,13 @@ impl event::EventHandler for State {
     }
 
     fn draw(&mut self, context: &mut Context) -> GameResult<()> {
-        graphics::clear(context);
-        graphics::set_background_color(context, [1.0, 1.0, 1.0, 1.0].into());
+        let bg_color = [1.0, 1.0, 1.0, 1.0].into();
+        graphics::clear(context, bg_color);
         self.gui.draw(context)?;
-        graphics::present(context);
-        Ok(())
+        graphics::present(context)
     }
 
-    fn resize_event(&mut self, context: &mut Context, w: u32, h: u32) {
+    fn resize_event(&mut self, context: &mut Context, w: f32, h: f32) {
         self.resize(context, w, h);
     }
 
@@ -81,10 +82,10 @@ impl event::EventHandler for State {
         &mut self,
         context: &mut Context,
         _: ggez::event::MouseButton,
-        x: i32,
-        y: i32,
+        x: f32,
+        y: f32,
     ) {
-        let window_pos = Point2::new(x as _, y as _);
+        let window_pos = Point2::new(x, y);
         let pos = ui::window_to_screen(context, window_pos);
         let message = self.gui.click(pos);
         println!("[{},{}] -> {}: {:?}", x, y, pos, message);
@@ -98,17 +99,19 @@ impl event::EventHandler for State {
     }
 }
 
-fn context() -> GameResult<ggez::Context> {
-    let name = "ggwp_zgui example text_button";
-    let window_conf = conf::WindowSetup::default().resizable(true).title(name);
+fn context() -> GameResult<(Context, event::EventsLoop)> {
+    let name = file!();
+    let window_conf = conf::WindowSetup::default().title(name);
+    let window_mode = conf::WindowMode::default().resizable(true);
     ContextBuilder::new(name, "ozkriff")
         .window_setup(window_conf)
+        .window_mode(window_mode)
         .add_resource_path("resources")
         .build()
 }
 
-fn main() -> GameResult<()> {
-    let mut context = context()?;
+fn main() -> GameResult {
+    let (mut context, mut events_loop) = context()?;
     let mut state = State::new(&mut context)?;
-    event::run(&mut context, &mut state)
+    event::run(&mut context, &mut events_loop, &mut state)
 }

--- a/ggwp-zgui/examples/text_button.rs
+++ b/ggwp-zgui/examples/text_button.rs
@@ -1,6 +1,7 @@
 use ggez::{
     conf, event,
-    graphics::{self, Font, Point2, Text},
+    graphics::{self, Font, Text},
+    nalgebra::Point2,
     Context, ContextBuilder, GameResult,
 };
 use ggwp_zgui as ui;
@@ -10,11 +11,12 @@ enum Message {
     Command,
 }
 
-fn make_gui(context: &mut Context, font: &Font) -> GameResult<ui::Gui<Message>> {
+fn make_gui(context: &mut Context, font: Font) -> GameResult<ui::Gui<Message>> {
+    let font_size = 32.0;
     let mut gui = ui::Gui::new(context);
     let anchor = ui::Anchor(ui::HAnchor::Right, ui::VAnchor::Bottom);
-    let image = Text::new(context, "[Button]", &font)?.into_inner();
-    let button = ui::Button::new(context, image, 0.2, gui.sender(), Message::Command);
+    let text = Box::new(Text::new(("[Button]", font, font_size)));
+    let button = ui::Button::new(context, text, 0.2, gui.sender(), Message::Command);
     gui.add(&ui::pack(button), anchor);
     Ok(gui)
 }
@@ -25,59 +27,60 @@ struct State {
 
 impl State {
     fn new(context: &mut Context) -> GameResult<State> {
-        let font = Font::new(context, "/Karla-Regular.ttf", 32)?;
-        let gui = make_gui(context, &font)?;
+        let font = Font::new(context, "/Karla-Regular.ttf")?;
+        let gui = make_gui(context, font)?;
         Ok(Self { gui })
     }
 
-    fn resize(&mut self, _: &mut Context, w: u32, h: u32) {
-        let aspect_ratio = w as f32 / h as f32;
+    fn resize(&mut self, _: &mut Context, w: f32, h: f32) {
+        let aspect_ratio = w / h;
         self.gui.resize(aspect_ratio);
     }
 }
 
 impl event::EventHandler for State {
-    fn update(&mut self, _: &mut Context) -> GameResult<()> {
+    fn update(&mut self, _: &mut Context) -> GameResult {
         Ok(())
     }
 
-    fn draw(&mut self, context: &mut Context) -> GameResult<()> {
-        graphics::set_background_color(context, [1.0, 1.0, 1.0, 1.0].into());
-        graphics::clear(context);
+    fn draw(&mut self, context: &mut Context) -> GameResult {
+        let bg_color = [1.0, 1.0, 1.0, 1.0].into();
+        graphics::clear(context, bg_color);
         self.gui.draw(context)?;
-        graphics::present(context);
-        Ok(())
+        graphics::present(context)
     }
 
-    fn resize_event(&mut self, context: &mut Context, w: u32, h: u32) {
+    fn resize_event(&mut self, context: &mut Context, w: f32, h: f32) {
         self.resize(context, w, h);
     }
 
     fn mouse_button_up_event(
         &mut self,
         context: &mut Context,
-        _: ggez::event::MouseButton,
-        x: i32,
-        y: i32,
+        _: event::MouseButton,
+        x: f32,
+        y: f32,
     ) {
-        let window_pos = Point2::new(x as _, y as _);
+        let window_pos = Point2::new(x, y);
         let pos = ui::window_to_screen(context, window_pos);
         let message = self.gui.click(pos);
         println!("[{},{}] -> {}: {:?}", x, y, pos, message);
     }
 }
 
-fn context() -> GameResult<ggez::Context> {
-    let name = "ggwp_zgui example text_button";
-    let window_conf = conf::WindowSetup::default().resizable(true).title(name);
+fn context() -> GameResult<(Context, event::EventsLoop)> {
+    let name = file!();
+    let window_conf = conf::WindowSetup::default().title(name);
+    let window_mode = conf::WindowMode::default().resizable(true);
     ContextBuilder::new(name, "ozkriff")
         .window_setup(window_conf)
+        .window_mode(window_mode)
         .add_resource_path("resources")
         .build()
 }
 
-fn main() -> GameResult<()> {
-    let mut context = context()?;
+fn main() -> GameResult {
+    let (mut context, mut events_loop) = context()?;
     let mut state = State::new(&mut context)?;
-    event::run(&mut context, &mut state)
+    event::run(&mut context, &mut events_loop, &mut state)
 }

--- a/ggwp-zscene/Cargo.toml
+++ b/ggwp-zscene/Cargo.toml
@@ -8,4 +8,5 @@ description = "Scene and Actions for GGEZ"
 keywords = ["ggez", "gamedev", "2D"]
 
 [dependencies]
-ggez = "0.4"
+# ggez = "0.5.0-rc.0" # TODO: get back to crates.io version
+ggez = { git = "https://github.com/ozkriff/ggez", rev = "7699cb33b" }

--- a/ggwp-zscene/src/action/move_by.rs
+++ b/ggwp-zscene/src/action/move_by.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use ggez::{graphics::Vector2, timer};
+use ggez::{nalgebra::Vector2, timer};
 
 use crate::{Action, Sprite};
 
@@ -8,12 +8,12 @@ use crate::{Action, Sprite};
 pub struct MoveBy {
     sprite: Sprite,
     duration: Duration,
-    delta: Vector2,
+    delta: Vector2<f32>,
     progress: Duration,
 }
 
 impl MoveBy {
-    pub fn new(sprite: &Sprite, delta: Vector2, duration: Duration) -> Self {
+    pub fn new(sprite: &Sprite, delta: Vector2<f32>, duration: Duration) -> Self {
         Self {
             sprite: sprite.clone(),
             delta,

--- a/src/geom.rs
+++ b/src/geom.rs
@@ -1,4 +1,4 @@
-use ggez::graphics::{Point2, Vector2};
+use ggez::nalgebra::{Point2, Vector2};
 use rand::{thread_rng, Rng};
 
 use crate::core::map::{hex_round, PosHex};
@@ -8,21 +8,21 @@ const SQRT_OF_3: f32 = 1.732_05;
 pub const FLATNESS_COEFFICIENT: f32 = 0.8;
 
 /// <http://www.redblobgames.com/grids/hexagons/#hex-to-pixel>
-pub fn hex_to_point(size: f32, hex: PosHex) -> Point2 {
+pub fn hex_to_point(size: f32, hex: PosHex) -> Point2<f32> {
     let x = size * SQRT_OF_3 * (hex.q as f32 + hex.r as f32 / 2.0);
     let y = size * 3.0 / 2.0 * hex.r as f32;
     Point2::new(x, y * FLATNESS_COEFFICIENT)
 }
 
 /// <http://www.redblobgames.com/grids/hexagons/#pixel-to-hex>
-pub fn point_to_hex(size: f32, mut point: Point2) -> PosHex {
+pub fn point_to_hex(size: f32, mut point: Point2<f32>) -> PosHex {
     point.y /= FLATNESS_COEFFICIENT;
     let q = (point.x * SQRT_OF_3 / 3.0 - point.y / 3.0) / size;
     let r = point.y * 2.0 / 3.0 / size;
     hex_round(PosHex { q, r })
 }
 
-pub fn rand_tile_offset(size: f32, radius: f32) -> Vector2 {
+pub fn rand_tile_offset(size: f32, radius: f32) -> Vector2<f32> {
     assert!(radius >= 0.0);
     let r = size * radius;
     Vector2::new(

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -1,11 +1,7 @@
 use log::info;
 use std::{fmt::Debug, time::Duration};
 
-use ggez::{
-    self,
-    graphics::{self, Point2},
-    Context,
-};
+use ggez::{self, graphics, nalgebra::Point2, Context};
 
 use crate::ZResult;
 
@@ -28,7 +24,7 @@ pub enum Transition {
 pub trait Screen: Debug {
     fn update(&mut self, context: &mut Context, dtime: Duration) -> ZResult<Transition>;
     fn draw(&self, context: &mut Context) -> ZResult;
-    fn click(&mut self, context: &mut Context, pos: Point2) -> ZResult<Transition>;
+    fn click(&mut self, context: &mut Context, pos: Point2<f32>) -> ZResult<Transition>;
     fn resize(&mut self, aspect_ratio: f32);
 }
 
@@ -46,20 +42,19 @@ impl Screens {
     }
 
     pub fn update(&mut self, context: &mut Context) -> ZResult {
-        let dtime = ggez::timer::get_delta(context);
+        let dtime = ggez::timer::delta(context);
         let command = self.screen_mut().update(context, dtime)?;
         self.handle_command(context, command)
     }
 
     pub fn draw(&self, context: &mut Context) -> ZResult {
-        graphics::set_background_color(context, [0.9, 0.9, 0.8, 1.0].into());
-        graphics::clear(context);
+        let bg_color = [0.9, 0.9, 0.8, 1.0].into();
+        graphics::clear(context, bg_color);
         self.screen().draw(context)?;
-        graphics::present(context);
-        Ok(())
+        graphics::present(context)
     }
 
-    pub fn click(&mut self, context: &mut Context, pos: Point2) -> ZResult {
+    pub fn click(&mut self, context: &mut Context, pos: Point2<f32>) -> ZResult {
         let command = self.screen_mut().click(context, pos)?;
         self.handle_command(context, command)
     }
@@ -82,7 +77,7 @@ impl Screens {
                 if self.screens.len() > 1 {
                     self.screens.pop().expect(ERR_MSG);
                 } else {
-                    context.quit()?;
+                    ggez::quit(context);
                 }
             }
         }

--- a/src/screen/battle/visualize.rs
+++ b/src/screen/battle/visualize.rs
@@ -1,8 +1,10 @@
 use std::time::Duration;
 
 use ggez::{
-    graphics::{Color, Point2, Text, Vector2},
-    nalgebra, Context,
+    graphics::{Color, Text},
+    nalgebra,
+    nalgebra::{Point2, Vector2},
+    Context,
 };
 use log::{debug, info};
 use rand::{thread_rng, Rng};
@@ -22,7 +24,7 @@ use crate::{
     },
     geom,
     screen::battle::view::BattleView,
-    utils::time_s,
+    utils::{font_size, time_s},
     ZResult,
 };
 
@@ -44,8 +46,9 @@ pub fn message(
 ) -> ZResult<Box<dyn Action>> {
     let visible = [0.0, 0.0, 0.0, 1.0].into();
     let invisible = Color { a: 0.0, ..visible };
-    let image = Text::new(context, text, view.font())?.into_inner();
-    let mut sprite = Sprite::from_image(image, 0.1);
+    let font_size = font_size();
+    let text = Box::new(Text::new((text, view.font(), font_size)));
+    let mut sprite = Sprite::from_drawable(context, text, 0.1);
     sprite.set_centered(true);
     let point = geom::hex_to_point(view.tile_size(), pos);
     let point = point - Vector2::new(0.0, view.tile_size() * 1.5);
@@ -68,13 +71,14 @@ pub fn message(
 pub fn attack_message(
     view: &mut BattleView,
     context: &mut Context,
-    pos: Point2,
+    pos: Point2<f32>,
     text: &str,
 ) -> ZResult<Box<dyn Action>> {
     let visible = [0.0, 0.0, 0.0, 1.0].into();
     let invisible = Color { a: 0.0, ..visible };
-    let image = Text::new(context, text, view.font())?.into_inner();
-    let mut sprite = Sprite::from_image(image, 0.1);
+    let font_size = font_size();
+    let text = Box::new(Text::new((text, view.font(), font_size)));
+    let mut sprite = Sprite::from_drawable(context, text, 0.1);
     sprite.set_centered(true);
     let point = pos + Vector2::new(0.0, view.tile_size() * 0.5);
     sprite.set_pos(point);
@@ -91,6 +95,7 @@ pub fn attack_message(
 
 fn show_blood_particles(
     view: &mut BattleView,
+    context: &mut Context,
     pos: PosHex,
     from: Option<Dir>,
     particles_count: i32,
@@ -110,7 +115,7 @@ fn show_blood_particles(
         let invisible = Color { a: 0.0, ..visible };
         let scale = thread_rng().gen_range(0.05, 0.15);
         let size = view.tile_size() * 2.0 * scale;
-        let mut sprite = Sprite::from_image(view.images().white_hex.clone(), size);
+        let mut sprite = Sprite::from_image(context, view.images().white_hex.clone(), size);
         sprite.set_centered(true);
         sprite.set_pos(point_origin);
         sprite.set_color(invisible);
@@ -128,8 +133,13 @@ fn show_blood_particles(
     Ok(fork(seq(actions)))
 }
 
-fn show_blood_spot(view: &mut BattleView, at: PosHex) -> ZResult<Box<dyn Action>> {
-    let mut sprite = Sprite::from_image(view.images().blood.clone(), view.tile_size() * 2.0);
+fn show_blood_spot(
+    view: &mut BattleView,
+    context: &mut Context,
+    at: PosHex,
+) -> ZResult<Box<dyn Action>> {
+    let mut sprite =
+        Sprite::from_image(context, view.images().blood.clone(), view.tile_size() * 2.0);
     sprite.set_centered(true);
     sprite.set_color([1.0, 1.0, 1.0, 0.0].into());
     let mut point = geom::hex_to_point(view.tile_size(), at);
@@ -145,13 +155,22 @@ fn show_blood_spot(view: &mut BattleView, at: PosHex) -> ZResult<Box<dyn Action>
     ]))
 }
 
-fn show_dust_at_pos(view: &mut BattleView, at: PosHex) -> ZResult<Box<dyn Action>> {
+fn show_dust_at_pos(
+    view: &mut BattleView,
+    context: &mut Context,
+    at: PosHex,
+) -> ZResult<Box<dyn Action>> {
     let point = geom::hex_to_point(view.tile_size(), at);
     let count = 9;
-    show_dust(view, point, count)
+    show_dust(view, context, point, count)
 }
 
-fn show_dust(view: &mut BattleView, at: Point2, count: i32) -> ZResult<Box<dyn Action>> {
+fn show_dust(
+    view: &mut BattleView,
+    context: &mut Context,
+    at: Point2<f32>,
+    count: i32,
+) -> ZResult<Box<dyn Action>> {
     let mut actions = Vec::new();
     for i in 0..count {
         let k = thread_rng().gen_range(0.8, 1.2);
@@ -169,7 +188,7 @@ fn show_dust(view: &mut BattleView, at: Point2, count: i32) -> ZResult<Box<dyn A
         };
         let point = at + vector;
         let sprite = {
-            let mut sprite = Sprite::from_image(view.images().white_hex.clone(), size);
+            let mut sprite = Sprite::from_image(context, view.images().white_hex.clone(), size);
             sprite.set_centered(true);
             sprite.set_pos(point);
             sprite.set_color(invisible);
@@ -192,6 +211,7 @@ fn show_dust(view: &mut BattleView, at: Point2, count: i32) -> ZResult<Box<dyn A
 
 fn show_flare_scale(
     view: &mut BattleView,
+    context: &mut Context,
     at: PosHex,
     color: Color,
     scale: f32,
@@ -199,7 +219,7 @@ fn show_flare_scale(
     let visible = color;
     let invisible = Color { a: 0.0, ..visible };
     let size = view.tile_size() * 2.0 * scale;
-    let mut sprite = Sprite::from_image(view.images().white_hex.clone(), size);
+    let mut sprite = Sprite::from_image(context, view.images().white_hex.clone(), size);
     let point = geom::hex_to_point(view.tile_size(), at);
     sprite.set_centered(true);
     sprite.set_pos(point);
@@ -214,6 +234,7 @@ fn show_flare_scale(
 
 fn show_weapon_flash(
     view: &mut BattleView,
+    context: &mut Context,
     at: PosHex,
     weapon_type: WeaponType,
 ) -> ZResult<Box<dyn Action>> {
@@ -227,7 +248,7 @@ fn show_weapon_flash(
         WeaponType::Pierce => view.images().attack_pierce.clone(),
         WeaponType::Claw => view.images().attack_claws.clone(),
     };
-    let mut sprite = Sprite::from_image(image, sprite_size);
+    let mut sprite = Sprite::from_image(context, image, sprite_size);
     let point = geom::hex_to_point(tile_size, at) - Vector2::new(0.0, tile_size * 0.3);
     sprite.set_centered(true);
     sprite.set_pos(point);
@@ -240,9 +261,14 @@ fn show_weapon_flash(
     ])))
 }
 
-fn show_flare(view: &mut BattleView, at: PosHex, color: Color) -> ZResult<Box<dyn Action>> {
+fn show_flare(
+    view: &mut BattleView,
+    context: &mut Context,
+    at: PosHex,
+    color: Color,
+) -> ZResult<Box<dyn Action>> {
     let scale = 1.0;
-    show_flare_scale(view, at, color, scale)
+    show_flare_scale(view, context, at, color, scale)
 }
 
 fn up_and_down_move(
@@ -264,8 +290,8 @@ fn up_and_down_move(
     ])
 }
 
-fn arc_move(view: &mut BattleView, sprite: &Sprite, diff: Vector2) -> Box<dyn Action> {
-    let len = nalgebra::norm(&diff);
+fn arc_move(view: &mut BattleView, sprite: &Sprite, diff: Vector2<f32>) -> Box<dyn Action> {
+    let len = nalgebra::Matrix::norm(&diff);
     let min_height = view.tile_size() * 0.5;
     let base_height = view.tile_size() * 2.0;
     let min_time = 0.25;
@@ -313,6 +339,7 @@ fn remove_brief_agent_info(view: &mut BattleView, id: ObjId) -> ZResult<Box<dyn 
 fn generate_brief_obj_info(
     state: &State,
     view: &mut BattleView,
+    context: &mut Context,
     id: ObjId,
 ) -> ZResult<Box<dyn Action>> {
     let image = view.images().dot.clone();
@@ -352,7 +379,7 @@ fn generate_brief_obj_info(
     let mut sprites = Vec::new();
     for &(color, point) in &dots {
         let color = color.into();
-        let mut sprite = Sprite::from_image(image.clone(), size);
+        let mut sprite = Sprite::from_image(context, image.clone(), size);
         sprite.set_centered(true);
         sprite.set_pos(point);
         sprite.set_color(Color { a: 0.0, ..color });
@@ -370,6 +397,7 @@ fn generate_brief_obj_info(
 pub fn refresh_brief_agent_info(
     state: &State,
     view: &mut BattleView,
+    context: &mut Context,
     id: ObjId,
 ) -> ZResult<Box<dyn Action>> {
     let mut actions = Vec::new();
@@ -377,7 +405,7 @@ pub fn refresh_brief_agent_info(
         actions.push(remove_brief_agent_info(view, id)?);
     }
     if state.parts().agent.get_opt(id).is_some() {
-        actions.push(generate_brief_obj_info(state, view, id)?);
+        actions.push(generate_brief_obj_info(state, view, context, id)?);
     }
     Ok(seq(actions))
 }
@@ -392,7 +420,7 @@ pub fn visualize(
     debug!("visualize: phase={:?} event={:?}", phase, event);
     match phase {
         ApplyPhase::Pre => visualize_pre(state, view, context, event),
-        ApplyPhase::Post => visualize_post(state, view, event),
+        ApplyPhase::Post => visualize_post(state, view, context, event),
     }
 }
 
@@ -417,16 +445,21 @@ fn visualize_pre(
     Ok(seq(actions))
 }
 
-fn visualize_post(state: &State, view: &mut BattleView, event: &Event) -> ZResult<Box<dyn Action>> {
+fn visualize_post(
+    state: &State,
+    view: &mut BattleView,
+    context: &mut Context,
+    event: &Event,
+) -> ZResult<Box<dyn Action>> {
     let mut actions = Vec::new();
     for &id in &event.actor_ids {
-        actions.push(refresh_brief_agent_info(state, view, id)?);
+        actions.push(refresh_brief_agent_info(state, view, context, id)?);
     }
     for &id in event.instant_effects.keys() {
-        actions.push(refresh_brief_agent_info(state, view, id)?);
+        actions.push(refresh_brief_agent_info(state, view, context, id)?);
     }
     for &id in event.timed_effects.keys() {
-        actions.push(refresh_brief_agent_info(state, view, id)?);
+        actions.push(refresh_brief_agent_info(state, view, context, id)?);
     }
     Ok(seq(actions))
 }
@@ -445,7 +478,7 @@ fn visualize_event(
         ActiveEvent::EndBattle(ref ev) => visualize_event_end_battle(state, view, context, ev)?,
         ActiveEvent::EndTurn(ref ev) => visualize_event_end_turn(state, view, context, ev),
         ActiveEvent::BeginTurn(ref ev) => visualize_event_begin_turn(state, view, context, ev)?,
-        ActiveEvent::EffectTick(ref ev) => visualize_event_effect_tick(state, view, ev)?,
+        ActiveEvent::EffectTick(ref ev) => visualize_event_effect_tick(state, view, context, ev)?,
         ActiveEvent::EffectEnd(ref ev) => visualize_event_effect_end(state, view, context, ev)?,
         ActiveEvent::UseAbility(ref ev) => visualize_event_use_ability(state, view, context, ev)?,
     };
@@ -493,7 +526,7 @@ fn visualize_create(
     };
     let sprite_shadow = {
         let image_shadow = view.images().shadow.clone();
-        let mut sprite = Sprite::from_image(image_shadow, size * shadow_size_coefficient);
+        let mut sprite = Sprite::from_image(context, image_shadow, size * shadow_size_coefficient);
         sprite.set_centered(true);
         sprite.set_color(Color { a: 0.0, ..color });
         sprite.set_pos(point);
@@ -569,7 +602,7 @@ fn visualize_event_attack(
     let action_shadow_move_from = action::MoveBy::new(&sprite_shadow, -diff, time_from).boxed();
     actions.push(fork(action_shadow_move_to));
     actions.push(action_sprite_move_to);
-    actions.push(show_weapon_flash(view, map_to, event.weapon_type)?);
+    actions.push(show_weapon_flash(view, context, map_to, event.weapon_type)?);
     actions.push(fork(action_shadow_move_from));
     actions.push(action_sprite_move_from);
     Ok(seq(actions))
@@ -589,8 +622,8 @@ fn visualize_event_end_battle(
         PlayerId(1) => "YOU LOSE!",
         _ => unreachable!(),
     };
-    let text = Text::new(context, &text, view.font())?;
-    let mut sprite = Sprite::from_image(text.into_inner(), 0.2);
+    let text = Box::new(Text::new((text, view.font(), font_size())));
+    let mut sprite = Sprite::from_drawable(context, text, 0.2);
     sprite.set_centered(true);
     sprite.set_color(invisible);
     Ok(seq(vec![
@@ -629,8 +662,8 @@ fn visualize_event_begin_turn(
         PlayerId(1) => "ENEMY TURN",
         _ => unreachable!(),
     };
-    let text = Text::new(context, text, view.font())?;
-    let mut sprite = Sprite::from_image(text.into_inner(), 0.2);
+    let text = Box::new(Text::new((text, view.font(), font_size())));
+    let mut sprite = Sprite::from_drawable(context, text, 0.2);
     sprite.set_centered(true);
     sprite.set_color(invisible);
     Ok(seq(vec![
@@ -645,7 +678,7 @@ fn visualize_event_begin_turn(
 fn visualize_event_use_ability_jump(
     state: &State,
     view: &mut BattleView,
-    _: &mut Context,
+    context: &mut Context,
     event: &event::UseAbility,
 ) -> ZResult<Box<dyn Action>> {
     let sprite_object = view.id_to_sprite(event.id).clone();
@@ -657,7 +690,7 @@ fn visualize_event_use_ability_jump(
     let action_arc_move = arc_move(view, &sprite_object, diff);
     let time = action_arc_move.duration();
     let action_move_shadow = action::MoveBy::new(&sprite_shadow, diff, time).boxed();
-    let action_dust = show_dust_at_pos(view, event.pos)?;
+    let action_dust = show_dust_at_pos(view, context, event.pos)?;
     Ok(seq(vec![
         fork(action_move_shadow),
         action_arc_move,
@@ -686,21 +719,23 @@ fn visualize_event_use_ability_dash(
 fn visualize_event_use_ability_explode(
     state: &State,
     view: &mut BattleView,
+    context: &mut Context,
     event: &event::UseAbility,
 ) -> ZResult<Box<dyn Action>> {
     let pos = state.parts().pos.get(event.id).0;
     let scale = 2.5;
-    show_flare_scale(view, pos, [1.0, 0.0, 0.0, 0.7].into(), scale).map(fork)
+    show_flare_scale(view, context, pos, [1.0, 0.0, 0.0, 0.7].into(), scale).map(fork)
 }
 
 fn visualize_event_use_ability_summon(
     state: &State,
     view: &mut BattleView,
+    context: &mut Context,
     event: &event::UseAbility,
 ) -> ZResult<Box<dyn Action>> {
     let pos = state.parts().pos.get(event.id).0;
     let scale = 2.0;
-    show_flare_scale(view, pos, [1.0, 1.0, 1.0, 0.7].into(), scale)
+    show_flare_scale(view, context, pos, [1.0, 1.0, 1.0, 0.7].into(), scale)
 }
 
 fn visualize_event_use_ability(
@@ -712,11 +747,11 @@ fn visualize_event_use_ability(
     let action_main = match event.ability {
         Ability::Jump(_) => visualize_event_use_ability_jump(state, view, context, event)?,
         Ability::Dash => visualize_event_use_ability_dash(state, view, context, event)?,
-        Ability::ExplodePush => visualize_event_use_ability_explode(state, view, event)?,
-        Ability::ExplodeDamage => visualize_event_use_ability_explode(state, view, event)?,
-        Ability::ExplodeFire => visualize_event_use_ability_explode(state, view, event)?,
-        Ability::ExplodePoison => visualize_event_use_ability_explode(state, view, event)?,
-        Ability::Summon => visualize_event_use_ability_summon(state, view, event)?,
+        Ability::ExplodePush => visualize_event_use_ability_explode(state, view, context, event)?,
+        Ability::ExplodeDamage => visualize_event_use_ability_explode(state, view, context, event)?,
+        Ability::ExplodeFire => visualize_event_use_ability_explode(state, view, context, event)?,
+        Ability::ExplodePoison => visualize_event_use_ability_explode(state, view, context, event)?,
+        Ability::Summon => visualize_event_use_ability_summon(state, view, context, event)?,
         _ => action::Empty::new().boxed(),
     };
     let pos = state.parts().pos.get(event.id).0;
@@ -730,12 +765,13 @@ fn visualize_event_use_ability(
 fn visualize_event_effect_tick(
     state: &State,
     view: &mut BattleView,
+    context: &mut Context,
     event: &event::EffectTick,
 ) -> ZResult<Box<dyn Action>> {
     let pos = state.parts().pos.get(event.id).0;
     match event.effect {
-        effect::Lasting::Poison => show_flare(view, pos, [0.0, 0.8, 0.0, 0.7].into()),
-        effect::Lasting::Stun => show_flare(view, pos, [1.0, 1.0, 1.0, 0.7].into()),
+        effect::Lasting::Poison => show_flare(view, context, pos, [0.0, 0.8, 0.0, 0.7].into()),
+        effect::Lasting::Stun => show_flare(view, context, pos, [1.0, 1.0, 1.0, 0.7].into()),
     }
 }
 
@@ -759,8 +795,8 @@ pub fn visualize_lasting_effect(
 ) -> ZResult<Box<dyn Action>> {
     let pos = state.parts().pos.get(target_id).0;
     let action_flare = match timed_effect.effect {
-        effect::Lasting::Poison => show_flare(view, pos, [0.0, 0.8, 0.0, 0.7].into())?,
-        effect::Lasting::Stun => show_flare(view, pos, [1.0, 1.0, 1.0, 0.7].into())?,
+        effect::Lasting::Poison => show_flare(view, context, pos, [0.0, 0.8, 0.0, 0.7].into())?,
+        effect::Lasting::Stun => show_flare(view, context, pos, [1.0, 1.0, 1.0, 0.7].into())?,
     };
     let s = timed_effect.effect.to_str();
     Ok(seq(vec![
@@ -812,10 +848,10 @@ fn visualize_effect_kill(
     let particles_count = 6;
     let pos = state.parts().pos.get(target_id).0;
     Ok(fork(seq(vec![
-        show_blood_particles(view, pos, effect.dir, particles_count)?,
+        show_blood_particles(view, context, pos, effect.dir, particles_count)?,
         message(view, context, pos, "killed")?,
         vanish(view, target_id),
-        show_blood_spot(view, pos)?,
+        show_blood_spot(view, context, pos)?,
     ])))
 }
 
@@ -850,7 +886,7 @@ fn visualize_effect_heal(
     Ok(seq(vec![
         action::Sleep::new(time_s(0.5)).boxed(),
         message(view, context, pos, &s)?,
-        show_flare(view, pos, [0.0, 0.0, 0.9, 0.7].into())?,
+        show_flare(view, context, pos, [0.0, 0.0, 0.9, 0.7].into())?,
     ]))
 }
 
@@ -890,6 +926,7 @@ fn visualize_effect_wound(
         let particles_count = effect.damage.0 * 4;
         actions.push(show_blood_particles(
             view,
+            context,
             pos,
             effect.dir,
             particles_count,
@@ -938,7 +975,7 @@ fn visualize_effect_fly_off(
     let action_main_move = arc_move(view, &sprite_object, diff);
     let time = action_main_move.duration();
     let action_move_shadow = action::MoveBy::new(&sprite_shadow, diff, time).boxed();
-    let action_dust = show_dust_at_pos(view, effect.to)?;
+    let action_dust = show_dust_at_pos(view, context, effect.to)?;
     Ok(fork(seq(vec![
         message(view, context, effect.to, "fly off")?,
         fork(action_move_shadow),
@@ -950,7 +987,7 @@ fn visualize_effect_fly_off(
 fn visualize_effect_throw(
     _: &State,
     view: &mut BattleView,
-    _: &mut Context,
+    context: &mut Context,
     target_id: ObjId,
     effect: &effect::Throw,
 ) -> ZResult<Box<dyn Action>> {
@@ -961,7 +998,7 @@ fn visualize_effect_throw(
     let diff = to - from;
     let arc_move = arc_move(view, &sprite, diff);
     let action_move_shadow = action::MoveBy::new(&sprite_shadow, diff, arc_move.duration()).boxed();
-    let action_dust = show_dust_at_pos(view, effect.to)?;
+    let action_dust = show_dust_at_pos(view, context, effect.to)?;
     Ok(seq(vec![fork(action_move_shadow), arc_move, action_dust]))
 }
 

--- a/src/screen/campaign.rs
+++ b/src/screen/campaign.rs
@@ -4,7 +4,8 @@ use std::{
 };
 
 use ggez::{
-    graphics::{self, Font, Point2, Text},
+    graphics::{self, Font, Text},
+    nalgebra::Point2,
     Context,
 };
 use log::info;
@@ -26,17 +27,19 @@ enum Message {
     Recruit(String),
 }
 
+const FONT_SIZE: f32 = utils::font_size();
+
 // TODO: Fix code duplication with `Battle` screen! (Move to `utils` mod?)
 fn line_height() -> f32 {
     0.08 * 1.5
 }
 
-fn basic_gui(context: &mut Context, font: &Font) -> ZResult<Gui<Message>> {
+fn basic_gui(context: &mut Context, font: Font) -> ZResult<Gui<Message>> {
     let mut gui = Gui::new(context);
     let h = line_height();
     let button_menu = {
-        let image = Text::new(context, "[exit]", font)?.into_inner();
-        ui::Button::new(context, image, h, gui.sender(), Message::Menu)
+        let text = Box::new(Text::new(("[exit]", font, FONT_SIZE)));
+        ui::Button::new(context, text, h, gui.sender(), Message::Menu)
     };
     let mut layout = ui::VLayout::new();
     layout.add(Box::new(button_menu));
@@ -47,20 +50,20 @@ fn basic_gui(context: &mut Context, font: &Font) -> ZResult<Gui<Message>> {
 
 fn add_agents_panel(
     context: &mut Context,
-    font: &Font,
+    font: Font,
     layout: &mut ui::VLayout,
     agents: &[String],
 ) -> ZResult {
     let h = line_height();
     {
         let text = "Your group consists of:";
-        let image = Text::new(context, text, font)?.into_inner();
-        layout.add(Box::new(ui::Label::new(context, image, h)));
+        let text = Box::new(Text::new((text, font, FONT_SIZE)));
+        layout.add(Box::new(ui::Label::new(context, text, h)));
     }
     for agent_type in agents {
         let text = format!("- {}", agent_type);
-        let image = Text::new(context, &text, font)?.into_inner();
-        let label = ui::Label::new(context, image, h);
+        let text = Box::new(Text::new((text.as_str(), font, FONT_SIZE)));
+        let label = ui::Label::new(context, text, h);
         layout.add(Box::new(label));
     }
     Ok(())
@@ -77,10 +80,10 @@ fn add_spacer(layout: &mut ui::VLayout) {
     layout.add(Box::new(ui::Spacer::new(rect)));
 }
 
-fn label(context: &mut Context, font: &Font, text: &str) -> ZResult<Box<dyn ui::Widget>> {
+fn label(context: &mut Context, font: Font, text: &str) -> ZResult<Box<dyn ui::Widget>> {
     let h = line_height();
-    let image = Text::new(context, text, font)?.into_inner();
-    Ok(Box::new(ui::Label::new(context, image, h)))
+    let text = Box::new(Text::new((text, font, FONT_SIZE)));
+    Ok(Box::new(ui::Label::new(context, text, h)))
 }
 
 #[derive(Debug)]
@@ -99,7 +102,7 @@ impl Campaign {
         let plan = utils::deserialize_from_file(context, "/campaign_01.ron")?;
         let state = State::from_plan(plan);
         let font = utils::default_font(context);
-        let gui = basic_gui(context, &font)?;
+        let gui = basic_gui(context, font)?;
         let mut this = Self {
             gui,
             font,
@@ -132,32 +135,32 @@ impl Campaign {
         if !casualties.is_empty() {
             layout.add(label(
                 context,
-                &self.font,
+                self.font,
                 "In the last battle you have lost:",
             )?);
             for agent_type in casualties {
                 let text = format!("- {} (killed)", agent_type);
-                let image = Text::new(context, &text, &self.font)?.into_inner();
-                let label = ui::Label::new(context, image, h);
+                let text = Box::new(Text::new((text.as_str(), self.font, FONT_SIZE)));
+                let label = ui::Label::new(context, text, h);
                 layout.add(Box::new(label));
             }
         }
 
         add_spacer(&mut layout);
-        add_agents_panel(context, &self.font, &mut layout, self.state.agents())?;
+        add_agents_panel(context, self.font, &mut layout, self.state.agents())?;
         add_spacer(&mut layout);
 
         if let Mode::PreparingForBattle = self.state.mode() {
             {
-                let image = Text::new(context, "Choose:", &self.font)?.into_inner();
-                layout.add(Box::new(ui::Label::new(context, image, h)));
+                let text = Box::new(Text::new(("Choose:", self.font, FONT_SIZE)));
+                layout.add(Box::new(ui::Label::new(context, text, h)));
             }
             for agent_type in self.state.aviable_recruits() {
                 let text = format!("- [Recruit {}]", agent_type);
-                let image = Text::new(context, &text, &self.font)?.into_inner();
+                let text = Box::new(Text::new((text.as_str(), self.font, FONT_SIZE)));
                 let sender = self.gui.sender();
                 let message = Message::Recruit(agent_type.to_string());
-                let button = ui::Button::new(context, image, h, sender, message);
+                let button = ui::Button::new(context, text, h, sender, message);
                 layout.add(Box::new(button));
             }
         }
@@ -172,7 +175,7 @@ impl Campaign {
 
     fn set_mode_ready(&mut self, context: &mut Context) -> ZResult {
         let mut layout = ui::VLayout::new();
-        add_agents_panel(context, &self.font, &mut layout, self.state.agents())?;
+        add_agents_panel(context, self.font, &mut layout, self.state.agents())?;
         let anchor = ui::Anchor(ui::HAnchor::Middle, ui::VAnchor::Middle);
         let layout = ui::pack(layout);
         self.gui.add(&layout, anchor);
@@ -184,9 +187,8 @@ impl Campaign {
                 self.state.current_scenario_index() + 1,
                 self.state.scenarios_count()
             );
-            let image = Text::new(context, text, &self.font)?.into_inner();
-            let button =
-                ui::Button::new(context, image, h, self.gui.sender(), Message::StartBattle);
+            let text = Box::new(Text::new((text.as_str(), self.font, FONT_SIZE)));
+            let button = ui::Button::new(context, text, h, self.gui.sender(), Message::StartBattle);
             let rc_button = ui::pack(button);
             let anchor = ui::Anchor(ui::HAnchor::Middle, ui::VAnchor::Bottom);
             self.gui.add(&rc_button, anchor);
@@ -220,8 +222,8 @@ impl Campaign {
 
     fn add_label_central_message(&mut self, context: &mut Context, text: &str) -> ZResult {
         let h = line_height() * 1.5;
-        let image = Text::new(context, text, &self.font)?.into_inner();
-        let label = ui::pack(ui::Label::new(context, image, h));
+        let text = Box::new(Text::new((text, self.font, FONT_SIZE)));
+        let label = ui::pack(ui::Label::new(context, text, h));
         let anchor = ui::Anchor(ui::HAnchor::Middle, ui::VAnchor::Middle);
         self.gui.add(&label, anchor);
         self.label_central_message = Some(label);
@@ -273,7 +275,7 @@ impl Screen for Campaign {
         self.gui.resize(aspect_ratio);
     }
 
-    fn click(&mut self, context: &mut Context, pos: Point2) -> ZResult<Transition> {
+    fn click(&mut self, context: &mut Context, pos: Point2<f32>) -> ZResult<Transition> {
         let message = self.gui.click(pos);
         info!(
             "StrategyScreen: click: pos={:?}, message={:?}",

--- a/src/screen/main_menu.rs
+++ b/src/screen/main_menu.rs
@@ -4,7 +4,8 @@ use std::{
 };
 
 use ggez::{
-    graphics::{Font, Point2, Text},
+    graphics::{Font, Text},
+    nalgebra::Point2,
     Context,
 };
 use log::debug;
@@ -25,24 +26,25 @@ enum Message {
     StartStrategyMap,
 }
 
-fn make_gui(context: &mut Context, font: &Font) -> ZResult<ui::Gui<Message>> {
+fn make_gui(context: &mut Context, font: Font) -> ZResult<ui::Gui<Message>> {
     let mut gui = ui::Gui::new(context);
     let h = 0.2;
+    let font_size = utils::font_size();
     let button_battle = {
-        let image = Text::new(context, "[demo battle]", font)?.into_inner();
-        ui::Button::new(context, image, h, gui.sender(), Message::StartInstant)
+        let text = Box::new(Text::new(("[demo battle]", font, font_size)));
+        ui::Button::new(context, text, h, gui.sender(), Message::StartInstant)
     };
     let button_campaign = {
-        let image = Text::new(context, "[campaign]", font)?.into_inner();
-        ui::Button::new(context, image, h, gui.sender(), Message::StartCampaign)
+        let text = Box::new(Text::new(("[campaign]", font, font_size)));
+        ui::Button::new(context, text, h, gui.sender(), Message::StartCampaign)
     };
     let button_strategy_map = {
-        let image = Text::new(context, "[strategy mode]", font)?.into_inner();
-        ui::Button::new(context, image, h, gui.sender(), Message::StartStrategyMap)
+        let text = Box::new(Text::new(("[strategy mode]", font, font_size)));
+        ui::Button::new(context, text, h, gui.sender(), Message::StartStrategyMap)
     };
     let button_exit = {
-        let image = Text::new(context, "[exit]", font)?.into_inner();
-        ui::Button::new(context, image, h, gui.sender(), Message::Exit)
+        let text = Box::new(Text::new(("[exit]", font, font_size)));
+        ui::Button::new(context, text, h, gui.sender(), Message::Exit)
     };
     let mut layout = ui::VLayout::new();
     layout.add(Box::new(button_battle));
@@ -64,7 +66,7 @@ pub struct MainMenu {
 impl MainMenu {
     pub fn new(context: &mut Context) -> ZResult<Self> {
         let font = utils::default_font(context);
-        let gui = make_gui(context, &font)?;
+        let gui = make_gui(context, font)?;
 
         let mut sprite = Sprite::from_path(context, "/tile.png", 0.1)?;
         sprite.set_centered(true);
@@ -91,7 +93,7 @@ impl Screen for MainMenu {
         self.gui.resize(aspect_ratio);
     }
 
-    fn click(&mut self, context: &mut Context, pos: Point2) -> ZResult<Transition> {
+    fn click(&mut self, context: &mut Context, pos: Point2<f32>) -> ZResult<Transition> {
         let message = self.gui.click(pos);
         debug!("MainMenu: click: pos={:?}, message={:?}", pos, message);
         match message {

--- a/src/screen/strategy_map.rs
+++ b/src/screen/strategy_map.rs
@@ -4,7 +4,8 @@ use std::{
 };
 
 use ggez::{
-    graphics::{self, Font, Point2, Text},
+    graphics::{self, Font, Text},
+    nalgebra::Point2,
     Context,
 };
 use log::info;
@@ -23,16 +24,17 @@ enum Message {
     StartBattle,
 }
 
-fn make_gui(context: &mut Context, font: &Font) -> ZResult<ui::Gui<Message>> {
+fn make_gui(context: &mut Context, font: Font) -> ZResult<ui::Gui<Message>> {
     let mut gui = ui::Gui::new(context);
     let h = 0.2;
+    let font_size = utils::font_size();
     let button_start_battle = {
-        let image = Text::new(context, "[start battle]", font)?.into_inner();
-        ui::Button::new(context, image, h, gui.sender(), Message::StartBattle)
+        let text = Box::new(Text::new(("[start battle]", font, font_size)));
+        ui::Button::new(context, text, h, gui.sender(), Message::StartBattle)
     };
     let button_menu = {
-        let image = Text::new(context, "[menu]", font)?.into_inner();
-        ui::Button::new(context, image, h, gui.sender(), Message::Menu)
+        let text = Box::new(Text::new(("[menu]", font, font_size)));
+        ui::Button::new(context, text, h, gui.sender(), Message::Menu)
     };
     let mut layout = ui::VLayout::new();
     layout.add(Box::new(button_start_battle));
@@ -68,7 +70,7 @@ pub struct StrategyMap {
 impl StrategyMap {
     pub fn new(context: &mut Context) -> ZResult<Self> {
         let font = utils::default_font(context);
-        let gui = make_gui(context, &font)?;
+        let gui = make_gui(context, font)?;
 
         let mut sprite = Sprite::from_path(context, "/tile.png", 0.1)?;
         sprite.set_centered(true);
@@ -104,7 +106,7 @@ impl Screen for StrategyMap {
         self.gui.resize(aspect_ratio);
     }
 
-    fn click(&mut self, context: &mut Context, pos: Point2) -> ZResult<Transition> {
+    fn click(&mut self, context: &mut Context, pos: Point2<f32>) -> ZResult<Transition> {
         let message = self.gui.click(pos);
         info!(
             "StrategyScreen: click: pos={:?}, message={:?}",

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -11,8 +11,13 @@ pub fn time_s(s: f32) -> Duration {
     Duration::from_millis(ms as u64)
 }
 
-pub fn check_assets_hash(fs: &mut Filesystem, expected: &str) -> ZResult {
-    let mut file = fs.open("/.checksum.md5")?;
+pub fn check_assets_hash(_fs: &mut Filesystem, expected: &str) -> ZResult {
+    use std::fs::File;
+    let mut file = File::open("assets/.checksum.md5")?;
+
+    // TODO: un-comment this when https://github.com/ggez/ggez/issues/570 is fixed
+    // let mut file = fs.open("/.checksum.md5")?;
+
     let mut data = String::new();
     file.read_to_string(&mut data)?;
     let real = data.trim();
@@ -27,7 +32,7 @@ pub fn check_assets_hash(fs: &mut Filesystem, expected: &str) -> ZResult {
 
 pub fn read_file_to_string<P: AsRef<Path>>(context: &mut Context, path: P) -> ZResult<String> {
     let mut buf = String::new();
-    let mut file = context.filesystem.open(path)?;
+    let mut file = ggez::filesystem::open(context, path)?;
     file.read_to_string(&mut buf)?;
     Ok(buf)
 }
@@ -39,10 +44,17 @@ where
 {
     let path = path.as_ref();
     let s = read_file_to_string(context, path)?;
-    let d = ron::de::from_str(&s).map_err(|e| format!("Can't deserialize {:?}: {:?}", path, e))?;
+    // TODO: Create a Zemeroth-specific error type
+    // let d = ron::de::from_str(&s).map_err(|e| format!("Can't deserialize {:?}: {:?}", path, e))?;
+    let d = ron::de::from_str(&s).expect("TODO: ERROR MESSAGE!");
     Ok(d)
 }
 
 pub fn default_font(context: &mut Context) -> Font {
-    Font::new(context, "/OpenSans-Regular.ttf", 32).expect("Can't load the default font")
+    Font::new(context, "/OpenSans-Regular.ttf").expect("Can't load the default font")
+}
+
+// TODO: Move to some config (https://github.com/ozkriff/zemeroth/issues/424)
+pub const fn font_size() -> f32 {
+    128.0
 }


### PR DESCRIPTION
GGEZ v0.5 isn't released yet and has some issues (https://github.com/ggez/ggez/issues/570, https://github.com/ggez/ggez/issues/569) but I believe I can switch to a git version of it for now.

Tech debt of this PR:

- https://github.com/ozkriff/zemeroth/issues/427 (Create a Zemeroth-specific error type)
- https://github.com/ozkriff/zemeroth/issues/424 (Move font size to some config)
- https://github.com/ozkriff/zemeroth/issues/428 (Assets check should use GGEZ's filesystem)

Part of #409 