### PR TITLE
'Line::Any' means "any line" now. The 'line' field is optional now.

### DIFF
--- a/src/core/battle/scenario.rs
+++ b/src/core/battle/scenario.rs
@@ -16,7 +16,7 @@ use crate::core::{
 pub struct ObjectsGroup {
     pub owner: Option<PlayerId>,
     pub typename: ObjType,
-    pub line: Line,
+    pub line: Option<Line>,
     pub count: i32,
 }
 
@@ -169,10 +169,10 @@ fn random_free_sector_pos(state: &State, player_id: PlayerId, line: Line) -> Opt
     None
 }
 
-pub fn random_pos(state: &State, owner: Option<PlayerId>, line: Line) -> Option<PosHex> {
-    match owner {
-        Some(player_id) => random_free_sector_pos(state, player_id, line),
-        None => random_free_pos(state),
+pub fn random_pos(state: &State, owner: Option<PlayerId>, line: Option<Line>) -> Option<PosHex> {
+    match (owner, line) {
+        (Some(player_id), Some(line)) => random_free_sector_pos(state, player_id, line),
+        _ => random_free_pos(state),
     }
 }
 

--- a/src/core/campaign.rs
+++ b/src/core/campaign.rs
@@ -167,7 +167,7 @@ mod tests {
         campaign::{Award, CampaignNode, Mode, Plan, State},
     };
 
-    type GroupTuple<'a> = (Option<PlayerId>, &'a str, Line, i32);
+    type GroupTuple<'a> = (Option<PlayerId>, &'a str, Option<Line>, i32);
 
     impl<'a> From<GroupTuple<'a>> for ObjectsGroup {
         fn from(tuple: GroupTuple) -> Self {
@@ -193,9 +193,9 @@ mod tests {
             let id_1 = Some(PlayerId(1));
             let scenario = Scenario {
                 objects: vec![
-                    (None, "boulder", Line::Any, 3).into(),
-                    (id_0, "swordsman", Line::Front, 1).into(),
-                    (id_1, "imp", Line::Front, 2).into(),
+                    (None, "boulder", None, 3).into(),
+                    (id_0, "swordsman", Some(Line::Front), 1).into(),
+                    (id_1, "imp", Some(Line::Front), 2).into(),
                 ],
                 ..scenario::default()
             };
@@ -217,9 +217,9 @@ mod tests {
             CampaignNode {
                 scenario: Scenario {
                     objects: vec![
-                        (None, "boulder", Line::Any, 3).into(),
-                        (id_0, "swordsman", Line::Front, 1).into(),
-                        (id_1, "imp", Line::Front, 2).into(),
+                        (None, "boulder", None, 3).into(),
+                        (id_0, "swordsman", Some(Line::Front), 1).into(),
+                        (id_1, "imp", Some(Line::Front), 2).into(),
                     ],
                     ..scenario::default()
                 },
@@ -230,8 +230,8 @@ mod tests {
             CampaignNode {
                 scenario: Scenario {
                     objects: vec![
-                        (None, "boulder", Line::Any, 3).into(),
-                        (id_1, "imp", Line::Front, 4).into(),
+                        (None, "boulder", None, 3).into(),
+                        (id_1, "imp", Some(Line::Front), 4).into(),
                     ],
                     ..scenario::default()
                 },

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,7 +89,7 @@ fn main() -> ZResult {
     const APP_ID: &str = "zemeroth";
     const APP_AUTHOR: &str = "ozkriff";
     const ASSETS_DIR_NAME: &str = "assets";
-    const ASSETS_HASHSUM: &str = "18e7de361e74471aeaec3f209ef63c3e";
+    const ASSETS_HASHSUM: &str = "a9ac7e886bb9319f7ec5cdddba24731b";
 
     fn enable_backtrace() {
         if std::env::var("RUST_BACKTRACE").is_err() {

--- a/src/screen/campaign.rs
+++ b/src/screen/campaign.rs
@@ -240,7 +240,7 @@ impl Campaign {
             scenario.objects.push(scenario::ObjectsGroup {
                 owner: Some(PlayerId(0)),
                 typename: typename.clone(),
-                line: scenario::Line::Middle,
+                line: Some(scenario::Line::Middle),
                 count: 1,
             });
         }


### PR DESCRIPTION
Closes #380 (_"\`Line::Any\` should mean "any line", not "any place on the map""_)