### PR TITLE
Hightlight a tile under the cursor

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,11 @@ impl event::EventHandler for MainState {
             .expect("Can't handle click event");
     }
 
-    fn mouse_motion_event(&mut self, context: &mut Context, x: f32, y: f32, _dx: f32, _dy: f32) {
+    fn mouse_motion_event(&mut self, context: &mut Context, x: f32, y: f32, dx: f32, dy: f32) {
+        if dx.abs() < 1.0 && dy.abs() < 1.0 {
+            // Don't do anything on touch devices
+            return;
+        }
         let window_pos = Point2::new(x, y);
         let pos = ui::window_to_screen(context, window_pos);
         self.screens

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,6 +74,14 @@ impl event::EventHandler for MainState {
             .expect("Can't handle click event");
     }
 
+    fn mouse_motion_event(&mut self, context: &mut Context, x: f32, y: f32, _dx: f32, _dy: f32) {
+        let window_pos = Point2::new(x, y);
+        let pos = ui::window_to_screen(context, window_pos);
+        self.screens
+            .move_mouse(context, pos)
+            .expect("Can't move the mouse");
+    }
+
     // This functions just overrides the default implementation,
     // because we don't want to quit from the game on `Esc`.
     #[cfg(not(target_arch = "wasm32"))] // <- we cant quit in wasm anyway

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -26,6 +26,10 @@ pub trait Screen: Debug {
     fn draw(&self, context: &mut Context) -> ZResult;
     fn click(&mut self, context: &mut Context, pos: Point2<f32>) -> ZResult<Transition>;
     fn resize(&mut self, aspect_ratio: f32);
+
+    fn move_mouse(&mut self, _context: &mut Context, _pos: Point2<f32>) -> ZResult {
+        Ok(())
+    }
 }
 
 const ERR_MSG: &str = "Screen stack is empty";
@@ -58,6 +62,10 @@ impl Screens {
     pub fn click(&mut self, context: &mut Context, pos: Point2<f32>) -> ZResult {
         let command = self.screen_mut().click(context, pos)?;
         self.handle_command(context, command)
+    }
+
+    pub fn move_mouse(&mut self, context: &mut Context, pos: Point2<f32>) -> ZResult {
+        self.screen_mut().move_mouse(context, pos)
     }
 
     pub fn resize(&mut self, aspect_ratio: f32) {

--- a/src/screen/battle.rs
+++ b/src/screen/battle.rs
@@ -510,4 +510,14 @@ impl Screen for Battle {
         }
         Ok(Transition::None)
     }
+
+    fn move_mouse(&mut self, _context: &mut Context, point: Point2<f32>) -> ZResult {
+        let pos = geom::point_to_hex(self.view.tile_size(), point);
+        if self.state.map().is_inboard(pos) {
+            self.view.show_current_tile_marker(pos);
+        } else {
+            self.view.hide_current_tile_marker();
+        }
+        Ok(())
+    }
 }

--- a/utils/wasm/build.sh
+++ b/utils/wasm/build.sh
@@ -2,6 +2,6 @@
 
 cp -r assets static
 cp utils/wasm/index.html static
-ls static > static/index.txt
+ls static | sed 's:^:/:' > static/index.txt
 cargo web build
 


### PR DESCRIPTION
![demo](https://i.imgur.com/laN1eaW.gif)

Highlighting is disabled on touch devices (by checking that dy/dx of cursor movement is zero).

Closes #458 (_"Highlight a tile under the cursor"_)

This PR also fixes leading slashes in the utils/wasm/build.sh script.