### PR TITLE
Add a mostly empty explicit rustfmt.toml file

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,4 @@
+# This project uses rustfmt with default options.
+
+# Let's just make sure that files use `\n` line endings.
+newline_style = "Unix"


### PR DESCRIPTION
The only non-default option for now is newline_style = 'Unix'

Motivation:
- https://github.com/ozkriff/zemeroth/issues/492 (_"editorconfig"_)
- https://reddit.com/r/rust/comments/9jl6a9/pro_tip_if_you_use_cargo_fmtrustfmt_use_a