### PR TITLE
Upgrade player's fighters between battles

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -102,7 +102,7 @@ fn main() -> ZResult {
     const APP_ID: &str = "zemeroth";
     const APP_AUTHOR: &str = "ozkriff";
     const ASSETS_DIR_NAME: &str = "assets";
-    const ASSETS_HASHSUM: &str = "2b90cce9970532b3a2e5678e650e38e8";
+    const ASSETS_HASHSUM: &str = "95a1bd6209b1b2b33cead60f40873c58";
 
     fn enable_backtrace() {
         if std::env::var("RUST_BACKTRACE").is_err() {


### PR DESCRIPTION
This PR provides experimental upgrades for swordsman and spearman:

![image](https://user-images.githubusercontent.com/662976/59642021-1ff29d80-916c-11e9-91cd-249786ac0959.png)

![image](https://user-images.githubusercontent.com/662976/59641899-b7a3bc00-916b-11e9-9cf8-418513517560.png)

Depends on:
- https://github.com/ozkriff/zemeroth_assets_src/commit/7ec5db6e2
- https://github.com/ozkriff/zemeroth_assets/commit/c82805336b

Closes #399 (_"Campaign: Add ability to upgrade player's fighters between battles"_)