### PR TITLE
Add hammerman and alchemist upgrades

### DIFF
--- a/src/core/battle/execute.rs
+++ b/src/core/battle/execute.rs
@@ -809,13 +809,23 @@ fn correct_damage_with_armor(
 }
 
 fn wound_or_kill(state: &State, id: ObjId, damage: battle::Strength) -> Effect {
+    let armor_break = battle::Strength(0);
+    wound_break_kill(state, id, damage, armor_break)
+}
+
+fn wound_break_kill(
+    state: &State,
+    id: ObjId,
+    damage: battle::Strength,
+    armor_break: battle::Strength,
+) -> Effect {
     let parts = state.parts();
     let strength = parts.strength.get(id).strength;
     let dir = None; // Let's assume that this is not a directed attack.
     if strength > damage {
         effect::Wound {
             damage,
-            armor_break: battle::Strength(0), // !!!
+            armor_break,
             dir,
         }
         .into()
@@ -908,7 +918,8 @@ fn execute_use_ability_explode_damage(
         }
         let damage = battle::Strength(1);
         let damage = correct_damage_with_armor(state, id, damage);
-        let effects = vec![wound_or_kill(state, id, damage)];
+        let armor_break = Strength(1);
+        let effects = vec![wound_break_kill(state, id, damage, armor_break)];
         context.instant_effects.push((id, effects));
     }
     assert!(context

--- a/src/core/battle/tests.rs
+++ b/src/core/battle/tests.rs
@@ -660,7 +660,7 @@ fn throw_bomb_damage() {
                         ObjId(1),
                         vec![effect::Wound {
                             damage: Strength(1),
-                            armor_break: Strength(0),
+                            armor_break: Strength(1),
                             dir: None,
                         }
                         .into()],

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,7 +102,7 @@ fn main() -> ZResult {
     const APP_ID: &str = "zemeroth";
     const APP_AUTHOR: &str = "ozkriff";
     const ASSETS_DIR_NAME: &str = "assets";
-    const ASSETS_HASHSUM: &str = "a77db27c0f1cd2975f4696e2d8993ca5";
+    const ASSETS_HASHSUM: &str = "c10b8cae8a1ff19a15ee98e4f29653ef";
 
     fn enable_backtrace() {
         if std::env::var("RUST_BACKTRACE").is_err() {


### PR DESCRIPTION
Most of the changes are done in https://github.com/ozkriff/zemeroth_assets/commit/ff01d06c6727becbd138aaad0829eb1ae98420a1

Also, this PR slows down heavy agents (they have 2 move points now) and make bomb explosions destroy one armor point.

![](https://i.imgur.com/MXch6kV.png)

Closes #504 (_"Create upgrades for alchemist and hammerman"_)