### PR TITLE
LICENSE-MIT: Fix/update years

### DIFF
--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,6 +1,6 @@
 MIT/X Consortium License
 
-@ 2013-2016 Andrey Lesnikov <ozkriff@gmail.com>
+@ 2017-2019 Andrey Lesnikov <ozkriff@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
Zemeroth was started in 2017, not in 2013. I guess I just copied the file from ZoC.