### PR TITLE
Weight logic to Knockback

### DIFF
--- a/src/core/battle.rs
+++ b/src/core/battle.rs
@@ -43,6 +43,13 @@ pub struct Id(i32);
 #[derive(Serialize, Deserialize, Default, Clone, Copy, Debug, PartialEq, PartialOrd)]
 pub struct Strength(pub i32);
 
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, PartialOrd)]
+pub enum Weight {
+    Normal,
+    Heavy,
+    Immovable,
+}
+
 #[derive(Serialize, Deserialize, Default, Clone, Copy, Debug, PartialEq, PartialOrd)]
 pub struct Attacks(pub i32);
 

--- a/src/core/battle.rs
+++ b/src/core/battle.rs
@@ -49,11 +49,13 @@ pub enum Weight {
     Heavy = 1,
     Immovable = 2,
 }
+
 impl Default for Weight {
     fn default() -> Self {
         Weight::Normal
     }
 }
+
 impl fmt::Display for Weight {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
@@ -69,7 +71,7 @@ pub struct PushStrength(pub Weight);
 
 impl PushStrength {
     pub fn can_push(self, weight: Weight) -> bool {
-        weight != Weight::Immovable && self.0 <= weight
+        weight != Weight::Immovable && self.0 >= weight
     }
 }
 

--- a/src/core/battle.rs
+++ b/src/core/battle.rs
@@ -1,4 +1,7 @@
-use std::default::Default;
+use std::{
+    default::Default,
+    fmt,
+};
 
 use serde::{Deserialize, Serialize};
 
@@ -45,9 +48,32 @@ pub struct Strength(pub i32);
 
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, PartialOrd)]
 pub enum Weight {
-    Normal,
-    Heavy,
-    Immovable,
+    Normal = 0,
+    Heavy = 1,
+    Immovable = 2,
+}
+impl Default for Weight {
+    fn default() -> Self {
+        Weight::Normal
+    }
+}
+impl fmt::Display for Weight {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+       match *self {
+        Weight::Normal => write!(f, "Normal"),
+        Weight::Heavy => write!(f, "Heavy"),
+        Weight::Immovable => write!(f, "Immovable"),
+       }
+    }
+}
+
+#[derive(Serialize, Deserialize, Default, Clone, Copy, Debug, PartialEq, PartialOrd)]
+pub struct PushStrength(pub Weight);
+
+impl PushStrength {
+    pub fn can_push(self, weight: Weight) -> bool {
+        weight != Weight::Immovable && self.0 <= weight
+    }
 }
 
 #[derive(Serialize, Deserialize, Default, Clone, Copy, Debug, PartialEq, PartialOrd)]

--- a/src/core/battle.rs
+++ b/src/core/battle.rs
@@ -1,7 +1,4 @@
-use std::{
-    default::Default,
-    fmt,
-};
+use std::{default::Default, fmt};
 
 use serde::{Deserialize, Serialize};
 
@@ -59,11 +56,11 @@ impl Default for Weight {
 }
 impl fmt::Display for Weight {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-       match *self {
-        Weight::Normal => write!(f, "Normal"),
-        Weight::Heavy => write!(f, "Heavy"),
-        Weight::Immovable => write!(f, "Immovable"),
-       }
+        match *self {
+            Weight::Normal => write!(f, "Normal"),
+            Weight::Heavy => write!(f, "Heavy"),
+            Weight::Immovable => write!(f, "Immovable"),
+        }
     }
 }
 

--- a/src/core/battle/ability.rs
+++ b/src/core/battle/ability.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use serde::{Deserialize, Serialize};
 
 use crate::core::{
-    battle::{Attacks, Strength},
+    battle::{Attacks, Strength, PushStrength},
     map::Distance,
 };
 
@@ -33,7 +33,7 @@ pub enum Ability {
 
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Knockback {
-    pub strength: Strength,
+    pub strength: PushStrength,
 }
 
 // TODO: use named fields?

--- a/src/core/battle/ability.rs
+++ b/src/core/battle/ability.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use serde::{Deserialize, Serialize};
 
 use crate::core::{
-    battle::{Attacks, Strength, PushStrength},
+    battle::{Attacks, PushStrength, Strength},
     map::Distance,
 };
 

--- a/src/core/battle/ability.rs
+++ b/src/core/battle/ability.rs
@@ -33,6 +33,7 @@ pub enum Ability {
 
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Knockback {
+    #[serde(default)]
     pub strength: PushStrength,
 }
 

--- a/src/core/battle/ability.rs
+++ b/src/core/battle/ability.rs
@@ -10,7 +10,7 @@ use crate::core::{
 /// Active ability.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, derive_more::From)]
 pub enum Ability {
-    Knockback,
+    Knockback(Knockback),
     Club,
     Jump(Jump),
     Poison,
@@ -29,6 +29,11 @@ pub enum Ability {
     Rage(Rage),
     Heal(Heal),
     Bloodlust,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Knockback {
+    pub strength: Strength,
 }
 
 // TODO: use named fields?
@@ -92,7 +97,7 @@ pub struct RechargeableAbility {
 impl fmt::Display for Ability {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Ability::Knockback => write!(f, "Knockback"),
+            Ability::Knockback(a) => write!(f, "Knockback-{}", a.strength.0),
             Ability::Club => write!(f, "Club"),
             Ability::Jump(a) => write!(f, "Jump-{}", (a.0).0),
             Ability::Poison => write!(f, "Poison"),

--- a/src/core/battle/check.rs
+++ b/src/core/battle/check.rs
@@ -101,7 +101,7 @@ fn check_command_use_ability(state: &State, command: &command::UseAbility) -> Re
     check_agent_can_attack(state, command.id)?;
     check_agent_ability_ready(state, command.id, &command.ability)?;
     match command.ability {
-        Ability::Knockback => check_ability_knockback(state, command.id, command.pos),
+        Ability::Knockback(a) => check_ability_knockback(state, command.id, command.pos, a),
         Ability::Club => check_ability_club(state, command.id, command.pos),
         Ability::Jump(a) => check_ability_jump(state, command.id, command.pos, a),
         Ability::Poison => check_ability_poison(state, command.id, command.pos),
@@ -123,7 +123,7 @@ fn check_command_use_ability(state: &State, command: &command::UseAbility) -> Re
     }
 }
 
-fn check_ability_knockback(state: &State, id: Id, pos: PosHex) -> Result<(), Error> {
+fn check_ability_knockback(state: &State, id: Id, pos: PosHex, _: ability::Knockback) -> Result<(), Error> {
     let selected_pos = state.parts().pos.get(id).0;
     check_min_distance(selected_pos, pos, Distance(1))?;
     check_max_distance(selected_pos, pos, Distance(1))?;

--- a/src/core/battle/check.rs
+++ b/src/core/battle/check.rs
@@ -123,7 +123,12 @@ fn check_command_use_ability(state: &State, command: &command::UseAbility) -> Re
     }
 }
 
-fn check_ability_knockback(state: &State, id: Id, pos: PosHex, _: ability::Knockback) -> Result<(), Error> {
+fn check_ability_knockback(
+    state: &State,
+    id: Id,
+    pos: PosHex,
+    _: ability::Knockback,
+) -> Result<(), Error> {
     let selected_pos = state.parts().pos.get(id).0;
     check_min_distance(selected_pos, pos, Distance(1))?;
     check_max_distance(selected_pos, pos, Distance(1))?;

--- a/src/core/battle/component.rs
+++ b/src/core/battle/component.rs
@@ -17,7 +17,9 @@ pub struct Pos(pub map::PosHex);
 
 /// Blocks the whole tile. Two blocker objects can't coexist in one tile.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub struct Blocker;
+pub struct Blocker {
+    pub weight: battle::Weight,
+}
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct Strength {

--- a/src/core/battle/component.rs
+++ b/src/core/battle/component.rs
@@ -18,6 +18,7 @@ pub struct Pos(pub map::PosHex);
 /// Blocks the whole tile. Two blocker objects can't coexist in one tile.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct Blocker {
+    #[serde(default)]
     pub weight: battle::Weight,
 }
 

--- a/src/core/battle/effect.rs
+++ b/src/core/battle/effect.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::core::{
     battle::{
         component::{Component, ObjType},
-        Phase, PosHex, Strength, PushStrength,
+        Phase, PosHex, PushStrength, Strength,
     },
     map::Dir,
 };

--- a/src/core/battle/effect.rs
+++ b/src/core/battle/effect.rs
@@ -110,6 +110,7 @@ pub struct Create {
 pub struct FlyOff {
     pub from: PosHex,
     pub to: PosHex,
+    pub strength: PushStrength,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq)]

--- a/src/core/battle/effect.rs
+++ b/src/core/battle/effect.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::core::{
     battle::{
         component::{Component, ObjType},
-        Phase, PosHex, Strength,
+        Phase, PosHex, Strength, PushStrength,
     },
     map::Dir,
 };
@@ -127,5 +127,5 @@ pub struct Dodge {
 pub struct Knockback {
     pub from: PosHex,
     pub to: PosHex,
-    // TODO: add strength there too ?
+    pub strength: PushStrength,
 }

--- a/src/core/battle/effect.rs
+++ b/src/core/battle/effect.rs
@@ -127,4 +127,5 @@ pub struct Dodge {
 pub struct Knockback {
     pub from: PosHex,
     pub to: PosHex,
+    // TODO: add strength there too ?
 }

--- a/src/core/battle/execute.rs
+++ b/src/core/battle/execute.rs
@@ -943,14 +943,12 @@ fn execute_use_ability_explode_push(
         let to = Dir::get_neighbor_pos(pos, dir);
         let mut effects = Vec::new();
         if state.map().is_inboard(to) && !state::is_tile_blocked(state, to) {
-            effects.push(
-                effect::Knockback {
-                    from: pos,
-                    to,
-                    strength: PushStrength { 0: Weight::Normal },
-                }
-                .into(),
-            );
+            let effect = effect::Knockback {
+                from: pos,
+                to,
+                strength: PushStrength(Weight::Normal),
+            };
+            effects.push(effect.into());
             context.moved_actor_ids.push(id);
         }
         context.instant_effects.push((id, effects));

--- a/src/core/battle/execute.rs
+++ b/src/core/battle/execute.rs
@@ -673,6 +673,7 @@ impl ExecuteContext {
 fn execute_use_ability_knockback(
     state: &mut State,
     command: &command::UseAbility,
+    _: ability::Knockback,
 ) -> ExecuteContext {
     let mut context = ExecuteContext::default();
     let id = state::blocker_id_at(state, command.pos);
@@ -680,6 +681,7 @@ fn execute_use_ability_knockback(
     let actor_pos = state.parts().pos.get(command.id).0;
     let dir = Dir::get_dir_from_to(actor_pos, command.pos);
     let to = Dir::get_neighbor_pos(command.pos, dir);
+    // Knockback strength might be used to push farther than 1 tile ?
     if state.map().is_inboard(to) && !state::is_tile_blocked(state, to) {
         let effect = effect::Knockback { from, to }.into();
         context.instant_effects.push((id, vec![effect]));
@@ -1126,7 +1128,7 @@ fn execute_use_ability_bloodlust(
 
 fn execute_use_ability(state: &mut State, cb: Cb, command: &command::UseAbility) {
     let mut context = match command.ability {
-        Ability::Knockback => execute_use_ability_knockback(state, command),
+        Ability::Knockback(a) => execute_use_ability_knockback(state, command, a),
         Ability::Club => execute_use_ability_club(state, command),
         Ability::Jump(_) => execute_use_ability_jump(state, command),
         Ability::Dash => execute_use_ability_dash(state, command),

--- a/src/core/battle/execute.rs
+++ b/src/core/battle/execute.rs
@@ -370,16 +370,14 @@ fn try_execute_passive_abilities_on_attack(
                     let dir = Dir::get_dir_from_to(attacker_pos, target_pos);
                     let from = target_pos;
                     let strength = PushStrength(Weight::Normal);
-                    let id = state::blocker_id_at(state, target_pos);
-                    let blocker_weight = state.parts().blocker.get(id).weight;
+                    let blocker_weight = state.parts().blocker.get(target_id).weight;
                     let to = if strength.can_push(blocker_weight) {
                         Dir::get_neighbor_pos(target_pos, dir)
                     } else {
                         from
                     };
-                    if to == from
-                        || state.map().is_inboard(to) && !state::is_tile_blocked(state, to)
-                    {
+                    let is_inboard = state.map().is_inboard(to);
+                    if to == from || is_inboard && !state::is_tile_blocked(state, to) {
                         let effect = effect::FlyOff { from, to, strength }.into();
                         effects.instant.push(effect);
                     }
@@ -696,7 +694,7 @@ fn execute_use_ability_knockback(
     } else {
         from
     };
-    if to == from || (state.map().is_inboard(to) && !state::is_tile_blocked(state, to)) {
+    if to == from || state.map().is_inboard(to) && !state::is_tile_blocked(state, to) {
         let effect = effect::Knockback { from, to, strength }.into();
         context.instant_effects.push((id, vec![effect]));
         context.moved_actor_ids.push(id);

--- a/src/core/battle/execute.rs
+++ b/src/core/battle/execute.rs
@@ -14,7 +14,7 @@ use crate::core::{
         event::{self, ActiveEvent, Event},
         movement::Path,
         state::{self, BattleResult, State},
-        Id, Moves, Phase, PlayerId, Strength, PushStrength, Weight
+        Id, Moves, Phase, PlayerId, PushStrength, Strength, Weight,
     },
     map::{self, Dir, PosHex},
     utils,
@@ -943,7 +943,14 @@ fn execute_use_ability_explode_push(
         let to = Dir::get_neighbor_pos(pos, dir);
         let mut effects = Vec::new();
         if state.map().is_inboard(to) && !state::is_tile_blocked(state, to) {
-            effects.push(effect::Knockback { from: pos, to, strength: PushStrength { 0: Weight::Normal } }.into());
+            effects.push(
+                effect::Knockback {
+                    from: pos,
+                    to,
+                    strength: PushStrength { 0: Weight::Normal },
+                }
+                .into(),
+            );
             context.moved_actor_ids.push(id);
         }
         context.instant_effects.push((id, effects));

--- a/src/core/battle/execute.rs
+++ b/src/core/battle/execute.rs
@@ -374,11 +374,12 @@ fn try_execute_passive_abilities_on_attack(
                     let blocker_weight = state.parts().blocker.get(id).weight;
                     let to = if strength.can_push(blocker_weight) {
                         Dir::get_neighbor_pos(target_pos, dir)
-                    }
-                    else {
+                    } else {
                         from
                     };
-                    if to == from || state.map().is_inboard(to) && !state::is_tile_blocked(state, to) {
+                    if to == from
+                        || state.map().is_inboard(to) && !state::is_tile_blocked(state, to)
+                    {
                         let effect = effect::FlyOff { from, to, strength }.into();
                         effects.instant.push(effect);
                     }
@@ -692,8 +693,7 @@ fn execute_use_ability_knockback(
     let blocker_weight = state.parts().blocker.get(id).weight;
     let to = if strength.can_push(blocker_weight) {
         Dir::get_neighbor_pos(command.pos, dir)
-    }
-    else {
+    } else {
         from
     };
     if to == from || (state.map().is_inboard(to) && !state::is_tile_blocked(state, to)) {

--- a/src/core/battle/execute.rs
+++ b/src/core/battle/execute.rs
@@ -952,10 +952,15 @@ fn execute_use_ability_explode_push(
         if distance.0 > 1 || command.id == id {
             continue;
         }
+        let blocker_weight = state.parts().blocker.get(id).weight;
         let dir = Dir::get_dir_from_to(from, pos);
-        let to = Dir::get_neighbor_pos(pos, dir);
+        let to = if PushStrength(Weight::Normal).can_push(blocker_weight) {
+            Dir::get_neighbor_pos(pos, dir)
+        } else {
+            pos
+        };
         let mut effects = Vec::new();
-        if state.map().is_inboard(to) && !state::is_tile_blocked(state, to) {
+        if to == pos || (state.map().is_inboard(to) && !state::is_tile_blocked(state, to)) {
             let effect = effect::Knockback {
                 from: pos,
                 to,

--- a/src/core/battle/state/apply.rs
+++ b/src/core/battle/state/apply.rs
@@ -5,7 +5,7 @@ use crate::core::battle::{
     component::{self, Component, Parts, PlannedAbility},
     effect::{self, Duration, Effect},
     event::{self, ActiveEvent, Event},
-    state, Attacks, Id, Jokers, Moves, Phase, PlayerId, State, Weight, 
+    state, Attacks, Id, Jokers, Moves, Phase, PlayerId, State, Weight,
 };
 
 pub fn apply(state: &mut State, event: &Event) {
@@ -339,12 +339,12 @@ fn apply_effect_wound(state: &mut State, id: Id, effect: &effect::Wound) {
 fn apply_effect_knockback(state: &mut State, id: Id, effect: &effect::Knockback) {
     assert!(state.map().is_inboard(effect.from));
     assert!(state.map().is_inboard(effect.to));
-    
+
     assert!(!state::is_tile_blocked(state, effect.to));
     let parts = state.parts_mut();
     if parts.blocker.get(id).weight == Weight::Normal {
         parts.pos.get_mut(id).0 = effect.to;
-        // TODO: push anyone who's in the way aside    
+        // TODO: push anyone who's in the way aside
     }
 }
 

--- a/src/core/battle/state/apply.rs
+++ b/src/core/battle/state/apply.rs
@@ -5,7 +5,7 @@ use crate::core::battle::{
     component::{self, Component, Parts, PlannedAbility},
     effect::{self, Duration, Effect},
     event::{self, ActiveEvent, Event},
-    state, Attacks, Id, Jokers, Moves, Phase, PlayerId, State,
+    state, Attacks, Id, Jokers, Moves, Phase, PlayerId, State, Weight, 
 };
 
 pub fn apply(state: &mut State, event: &Event) {
@@ -339,10 +339,13 @@ fn apply_effect_wound(state: &mut State, id: Id, effect: &effect::Wound) {
 fn apply_effect_knockback(state: &mut State, id: Id, effect: &effect::Knockback) {
     assert!(state.map().is_inboard(effect.from));
     assert!(state.map().is_inboard(effect.to));
+    
     assert!(!state::is_tile_blocked(state, effect.to));
     let parts = state.parts_mut();
-    parts.pos.get_mut(id).0 = effect.to;
-    // TODO: push anyone who's in the way aside
+    if parts.blocker.get(id).weight == Weight::Normal {
+        parts.pos.get_mut(id).0 = effect.to;
+        // TODO: push anyone who's in the way aside    
+    }
 }
 
 fn apply_effect_fly_off(state: &mut State, id: Id, effect: &effect::FlyOff) {

--- a/src/core/battle/state/apply.rs
+++ b/src/core/battle/state/apply.rs
@@ -5,7 +5,7 @@ use crate::core::battle::{
     component::{self, Component, Parts, PlannedAbility},
     effect::{self, Duration, Effect},
     event::{self, ActiveEvent, Event},
-    state, Attacks, Id, Jokers, Moves, Phase, PlayerId, State, Weight,
+    state, Attacks, Id, Jokers, Moves, Phase, PlayerId, State,
 };
 
 pub fn apply(state: &mut State, event: &Event) {
@@ -342,10 +342,11 @@ fn apply_effect_knockback(state: &mut State, id: Id, effect: &effect::Knockback)
 
     assert!(!state::is_tile_blocked(state, effect.to));
     let parts = state.parts_mut();
-    if parts.blocker.get(id).weight == Weight::Normal {
+    if effect.strength.can_push(parts.blocker.get(id).weight) {
         parts.pos.get_mut(id).0 = effect.to;
-        // TODO: push anyone who's in the way aside
     }
+    // else show a resistance ?
+    // TODO: push anyone who's in the way aside
 }
 
 fn apply_effect_fly_off(state: &mut State, id: Id, effect: &effect::FlyOff) {

--- a/src/core/battle/state/apply.rs
+++ b/src/core/battle/state/apply.rs
@@ -339,7 +339,6 @@ fn apply_effect_wound(state: &mut State, id: Id, effect: &effect::Wound) {
 fn apply_effect_knockback(state: &mut State, id: Id, effect: &effect::Knockback) {
     assert!(state.map().is_inboard(effect.from));
     assert!(state.map().is_inboard(effect.to));
-
     assert!(!state::is_tile_blocked(state, effect.to));
     let parts = state.parts_mut();
     if effect.strength.can_push(parts.blocker.get(id).weight) {

--- a/src/core/battle/state/apply.rs
+++ b/src/core/battle/state/apply.rs
@@ -338,18 +338,20 @@ fn apply_effect_wound(state: &mut State, id: Id, effect: &effect::Wound) {
 
 fn apply_effect_knockback(state: &mut State, id: Id, effect: &effect::Knockback) {
     assert!(state.map().is_inboard(effect.from));
+    if effect.to == effect.from {
+        return;
+    }
     assert!(state.map().is_inboard(effect.to));
     assert!(!state::is_tile_blocked(state, effect.to));
     let parts = state.parts_mut();
-    if effect.strength.can_push(parts.blocker.get(id).weight) {
-        parts.pos.get_mut(id).0 = effect.to;
-    }
-    // else show a resistance ?
-    // TODO: push anyone who's in the way aside
+    parts.pos.get_mut(id).0 = effect.to;
 }
 
 fn apply_effect_fly_off(state: &mut State, id: Id, effect: &effect::FlyOff) {
     assert!(state.map().is_inboard(effect.from));
+    if effect.to == effect.from {
+        return;
+    }
     assert!(state.map().is_inboard(effect.to));
     assert!(!state::is_tile_blocked(state, effect.to));
     let parts = state.parts_mut();

--- a/src/core/battle/tests.rs
+++ b/src/core/battle/tests.rs
@@ -1464,7 +1464,7 @@ fn knockback_normal_vs_normal() {
             ],
         ),
         (
-            "weak",
+            "normal_target",
             [
                 component_agent_dull(),
                 component_strength(1),
@@ -1473,22 +1473,23 @@ fn knockback_normal_vs_normal() {
             .to_vec(),
         ),
     ]);
-    let initial_weak_position = PosHex { q: 0, r: 3 };
+    let target_position_initial = PosHex { q: 0, r: 1 };
+    let target_position_updated = PosHex { q: 0, r: 2 };
     let scenario = scenario::default()
-        .object(P0, "knockbacker", PosHex { q: 0, r: 2 })
-        .object(P1, "weak", initial_weak_position);
+        .object(P0, "knockbacker", PosHex { q: 0, r: 0 })
+        .object(P1, "normal_target", target_position_initial);
     let mut state = debug_state(prototypes, scenario);
     exec_and_check(
         &mut state,
         command::UseAbility {
             id: Id(0),
-            pos: initial_weak_position,
+            pos: target_position_initial,
             ability: ability_knockback_normal(),
         },
         &[Event {
             active_event: event::UseAbility {
                 id: Id(0),
-                pos: initial_weak_position,
+                pos: target_position_initial,
                 ability: ability::Knockback {
                     strength: PushStrength(Weight::Normal),
                 }
@@ -1499,9 +1500,9 @@ fn knockback_normal_vs_normal() {
             instant_effects: vec![(
                 Id(1),
                 vec![effect::Knockback {
-                    from: initial_weak_position,
-                    to: PosHex { q: 0, r: 4 },
-                    strength: PushStrength { 0: Weight::Normal },
+                    from: target_position_initial,
+                    to: target_position_updated,
+                    strength: PushStrength(Weight::Normal),
                 }
                 .into()],
             )],
@@ -1509,7 +1510,7 @@ fn knockback_normal_vs_normal() {
             scheduled_abilities: Vec::new(),
         }],
     );
-    assert_eq!(state.parts().pos.get(Id(1)).0, PosHex { q: 0, r: 4 });
+    assert_eq!(state.parts().pos.get(Id(1)).0, target_position_updated);
 }
 
 #[test]
@@ -1523,7 +1524,7 @@ fn knockback_normal_vs_heavy() {
             ],
         ),
         (
-            "heavy",
+            "heavy_target",
             [
                 component_agent_dull(),
                 component_strength(1),
@@ -1532,10 +1533,10 @@ fn knockback_normal_vs_heavy() {
             .to_vec(),
         ),
     ]);
-    let initial_heavy_position = PosHex { q: 0, r: 3 };
+    let initial_heavy_position = PosHex { q: 0, r: 1 };
     let scenario = scenario::default()
-        .object(P0, "knockbacker", PosHex { q: 0, r: 2 })
-        .object(P1, "heavy", initial_heavy_position);
+        .object(P0, "knockbacker", PosHex { q: 0, r: 0 })
+        .object(P1, "heavy_target", initial_heavy_position);
     let mut state = debug_state(prototypes, scenario);
     exec_and_check(
         &mut state,

--- a/src/core/battle/tests.rs
+++ b/src/core/battle/tests.rs
@@ -16,13 +16,7 @@ use crate::core::{
         movement::Path,
         scenario::{self, ExactObject, Scenario},
         state::BattleResult,
-<<<<<<< HEAD
-        Accuracy, Attacks, Dodge, Id, Jokers, MovePoints, Moves, Phase, PlayerId, State,
-        Strength, Weight
-=======
-        Accuracy, Attacks, Dodge, Id, Jokers, MovePoints, Moves, Phase, PlayerId, State, Strength,
-        Weight,
->>>>>>> cargo fmt
+        Accuracy, Attacks, Dodge, Id, Jokers, MovePoints, Moves, Phase, PlayerId, State, Strength, PushStrength, Weight,
     },
     map::{Dir, Distance, PosHex},
 };
@@ -1269,11 +1263,21 @@ fn throw_bomb_push() {
             ]
             .to_vec(),
         ),
+        (
+            "heavy",
+            [
+                component_agent_dull(),
+                component_strength(1),
+                component_blocker(Weight::Normal),
+            ]
+            .to_vec(),
+        ),
         ("bomb_push", Vec::new()),
     ]);
     let scenario = scenario::default()
         .object(P0, "thrower", PosHex { q: 0, r: 0 })
-        .object(P1, "weak", PosHex { q: 0, r: 3 });
+        .object(P1, "weak", PosHex { q: 0, r: 3 })
+        .object(P1, "heavy", PosHex { q: 1, r: 2 });
     let mut state = debug_state(prototypes, scenario);
     exec_and_check(
         &mut state,
@@ -1295,7 +1299,7 @@ fn throw_bomb_push() {
                 .into(),
                 actor_ids: vec![Id(0)],
                 instant_effects: vec![(
-                    Id(2),
+                    Id(3),
                     vec![
                         effect::Create {
                             pos: PosHex { q: 0, r: 0 },
@@ -1315,7 +1319,7 @@ fn throw_bomb_push() {
                 )],
                 timed_effects: Vec::new(),
                 scheduled_abilities: vec![(
-                    Id(2),
+                    Id(3),
                     vec![PlannedAbility {
                         rounds: 0,
                         phase: Phase(0),
@@ -1325,22 +1329,32 @@ fn throw_bomb_push() {
             },
             Event {
                 active_event: event::UseAbility {
-                    id: Id(2),
+                    id: Id(3),
                     pos: PosHex { q: 0, r: 2 },
                     ability: Ability::ExplodePush,
                 }
                 .into(),
-                actor_ids: vec![Id(2)],
+                actor_ids: vec![Id(3)],
                 instant_effects: vec![
                     (
                         Id(1),
                         vec![effect::Knockback {
                             from: PosHex { q: 0, r: 3 },
                             to: PosHex { q: 0, r: 4 },
+                            strength: PushStrength { 0: Weight::Normal },
                         }
                         .into()],
                     ),
-                    (Id(2), vec![Effect::Vanish]),
+                    (
+                        Id(2),
+                        vec![effect::Knockback {
+                            from: PosHex { q: 1, r: 2 },
+                            to: PosHex { q: 2, r: 2 },
+                            strength: PushStrength { 0: Weight::Normal },
+                        }
+                        .into()],
+                    ),
+                    (Id(3), vec![Effect::Vanish]),
                 ],
                 timed_effects: Vec::new(),
                 scheduled_abilities: Vec::new(),

--- a/src/core/battle/tests.rs
+++ b/src/core/battle/tests.rs
@@ -1484,32 +1484,29 @@ fn knockback_normal_vs_normal() {
             pos: initial_weak_position,
             ability: ability_knockback_normal(),
         },
-        &[
-            Event {
-                active_event: event::UseAbility {
-                    id: Id(0),
-                    pos: initial_weak_position,
-                    ability: ability::Knockback {
-                        strength: PushStrength(Weight::Normal),
-                    }.into(),
+        &[Event {
+            active_event: event::UseAbility {
+                id: Id(0),
+                pos: initial_weak_position,
+                ability: ability::Knockback {
+                    strength: PushStrength(Weight::Normal),
                 }
                 .into(),
-                actor_ids: vec![Id(1), Id(0)],
-                instant_effects: vec![
-                    (
-                        Id(1),
-                        vec![effect::Knockback {
-                            from: initial_weak_position,
-                            to: PosHex { q: 0, r: 4 },
-                            strength: PushStrength { 0: Weight::Normal },
-                        }
-                        .into()],
-                    ),
-                ],
-                timed_effects: Vec::new(),
-                scheduled_abilities: Vec::new(),
-            },
-        ],
+            }
+            .into(),
+            actor_ids: vec![Id(1), Id(0)],
+            instant_effects: vec![(
+                Id(1),
+                vec![effect::Knockback {
+                    from: initial_weak_position,
+                    to: PosHex { q: 0, r: 4 },
+                    strength: PushStrength { 0: Weight::Normal },
+                }
+                .into()],
+            )],
+            timed_effects: Vec::new(),
+            scheduled_abilities: Vec::new(),
+        }],
     );
     assert_eq!(state.parts().pos.get(Id(1)).0, PosHex { q: 0, r: 4 });
 }
@@ -1545,32 +1542,29 @@ fn knockback_normal_vs_heavy() {
             pos: initial_heavy_position,
             ability: ability_knockback_normal(),
         },
-        &[
-            Event {
-                active_event: event::UseAbility {
-                    id: Id(0),
-                    pos: initial_heavy_position,
-                    ability: ability::Knockback {
-                        strength: PushStrength(Weight::Normal),
-                    }.into(),
+        &[Event {
+            active_event: event::UseAbility {
+                id: Id(0),
+                pos: initial_heavy_position,
+                ability: ability::Knockback {
+                    strength: PushStrength(Weight::Normal),
                 }
                 .into(),
-                actor_ids: vec![Id(1), Id(0)],
-                instant_effects: vec![
-                    (
-                        Id(1),
-                        vec![effect::Knockback {
-                            from: initial_heavy_position,
-                            to: initial_heavy_position,
-                            strength: PushStrength { 0: Weight::Normal },
-                        }
-                        .into()],
-                    ),
-                ],
-                timed_effects: Vec::new(),
-                scheduled_abilities: Vec::new(),
-            },
-        ],
+            }
+            .into(),
+            actor_ids: vec![Id(1), Id(0)],
+            instant_effects: vec![(
+                Id(1),
+                vec![effect::Knockback {
+                    from: initial_heavy_position,
+                    to: initial_heavy_position,
+                    strength: PushStrength { 0: Weight::Normal },
+                }
+                .into()],
+            )],
+            timed_effects: Vec::new(),
+            scheduled_abilities: Vec::new(),
+        }],
     );
     assert_eq!(state.parts().pos.get(Id(1)).0, initial_heavy_position);
 }

--- a/src/core/battle/tests.rs
+++ b/src/core/battle/tests.rs
@@ -16,7 +16,8 @@ use crate::core::{
         movement::Path,
         scenario::{self, ExactObject, Scenario},
         state::BattleResult,
-        Accuracy, Attacks, Dodge, Id, Jokers, MovePoints, Moves, Phase, PlayerId, State, Strength,
+        Accuracy, Attacks, Dodge, Id, Jokers, MovePoints, Moves, Phase, PlayerId, State,
+        Strength, Weight
     },
     map::{Dir, Distance, PosHex},
 };
@@ -119,8 +120,10 @@ fn component_strength(n: i32) -> Component {
     .into()
 }
 
-fn component_blocker() -> Component {
-    component::Blocker.into()
+fn component_blocker(w: Weight) -> Component {
+    component::Blocker {
+        weight: w,
+    }.into()
 }
 
 fn component_abilities(abilities: &[Ability]) -> Component {
@@ -1175,7 +1178,7 @@ fn stun() {
             "target",
             vec![
                 component_agent_dull(),
-                component_blocker(),
+                component_blocker(Weight::Normal),
                 component_strength(1),
             ],
         ),
@@ -1256,7 +1259,7 @@ fn throw_bomb_push() {
         ),
         (
             "weak",
-            [component_agent_dull(), component_strength(1)].to_vec(),
+            [component_agent_dull(), component_strength(1), component_blocker(Weight::Normal)].to_vec(),
         ),
         ("bomb_push", Vec::new()),
     ]);

--- a/src/core/battle/tests.rs
+++ b/src/core/battle/tests.rs
@@ -1246,7 +1246,7 @@ fn stun() {
 }
 
 #[test]
-fn throw_bomb_push() {
+fn throw_bomb_push_normal() {
     let prototypes = prototypes(&[
         (
             "thrower",
@@ -1264,6 +1264,96 @@ fn throw_bomb_push() {
             ]
             .to_vec(),
         ),
+        ("bomb_push", Vec::new()),
+    ]);
+    let scenario = scenario::default()
+        .object(P0, "thrower", PosHex { q: 0, r: 0 })
+        .object(P1, "weak", PosHex { q: 0, r: 3 });
+    let mut state = debug_state(prototypes, scenario);
+    exec_and_check(
+        &mut state,
+        command::UseAbility {
+            id: Id(0),
+            pos: PosHex { q: 0, r: 2 },
+            ability: ability_throw_bomb_push(),
+        },
+        &[
+            Event {
+                active_event: event::UseAbility {
+                    id: Id(0),
+                    pos: PosHex { q: 0, r: 2 },
+                    ability: ability::BombPush {
+                        throw_distance: Distance(2),
+                    }
+                    .into(),
+                }
+                .into(),
+                actor_ids: vec![Id(0)],
+                instant_effects: vec![(
+                    Id(2),
+                    vec![
+                        effect::Create {
+                            pos: PosHex { q: 0, r: 0 },
+                            prototype: "bomb_push".into(),
+                            components: vec![
+                                component::Pos(PosHex { q: 0, r: 0 }).into(),
+                                component_meta("bomb_push"),
+                            ],
+                        }
+                        .into(),
+                        effect::Throw {
+                            from: PosHex { q: 0, r: 0 },
+                            to: PosHex { q: 0, r: 2 },
+                        }
+                        .into(),
+                    ],
+                )],
+                timed_effects: Vec::new(),
+                scheduled_abilities: vec![(
+                    Id(2),
+                    vec![PlannedAbility {
+                        rounds: 0,
+                        phase: Phase(0),
+                        ability: Ability::ExplodePush,
+                    }],
+                )],
+            },
+            Event {
+                active_event: event::UseAbility {
+                    id: Id(2),
+                    pos: PosHex { q: 0, r: 2 },
+                    ability: Ability::ExplodePush,
+                }
+                .into(),
+                actor_ids: vec![Id(2)],
+                instant_effects: vec![
+                    (
+                        Id(1),
+                        vec![effect::Knockback {
+                            from: PosHex { q: 0, r: 3 },
+                            to: PosHex { q: 0, r: 4 },
+                            strength: PushStrength { 0: Weight::Normal },
+                        }
+                        .into()],
+                    ),
+                    (Id(2), vec![Effect::Vanish]),
+                ],
+                timed_effects: Vec::new(),
+                scheduled_abilities: Vec::new(),
+            },
+        ],
+    );
+}
+#[test]
+fn throw_bomb_push_heavy() {
+    let prototypes = prototypes(&[
+        (
+            "thrower",
+            vec![
+                component_agent_one_attack(),
+                component_abilities(&[ability_throw_bomb_push()]),
+            ],
+        ),
         (
             "heavy",
             [
@@ -1277,7 +1367,6 @@ fn throw_bomb_push() {
     ]);
     let scenario = scenario::default()
         .object(P0, "thrower", PosHex { q: 0, r: 0 })
-        .object(P1, "weak", PosHex { q: 0, r: 3 })
         .object(P1, "heavy", PosHex { q: 1, r: 2 });
     let mut state = debug_state(prototypes, scenario);
     exec_and_check(
@@ -1300,7 +1389,7 @@ fn throw_bomb_push() {
                 .into(),
                 actor_ids: vec![Id(0)],
                 instant_effects: vec![(
-                    Id(3),
+                    Id(2),
                     vec![
                         effect::Create {
                             pos: PosHex { q: 0, r: 0 },
@@ -1320,7 +1409,7 @@ fn throw_bomb_push() {
                 )],
                 timed_effects: Vec::new(),
                 scheduled_abilities: vec![(
-                    Id(3),
+                    Id(2),
                     vec![PlannedAbility {
                         rounds: 0,
                         phase: Phase(0),
@@ -1330,24 +1419,15 @@ fn throw_bomb_push() {
             },
             Event {
                 active_event: event::UseAbility {
-                    id: Id(3),
+                    id: Id(2),
                     pos: PosHex { q: 0, r: 2 },
                     ability: Ability::ExplodePush,
                 }
                 .into(),
-                actor_ids: vec![Id(3)],
+                actor_ids: vec![Id(2)],
                 instant_effects: vec![
                     (
                         Id(1),
-                        vec![effect::Knockback {
-                            from: PosHex { q: 0, r: 3 },
-                            to: PosHex { q: 0, r: 4 },
-                            strength: PushStrength { 0: Weight::Normal },
-                        }
-                        .into()],
-                    ),
-                    (
-                        Id(2),
                         vec![effect::Knockback {
                             from: PosHex { q: 1, r: 2 },
                             to: PosHex { q: 2, r: 2 },
@@ -1355,7 +1435,7 @@ fn throw_bomb_push() {
                         }
                         .into()],
                     ),
-                    (Id(3), vec![Effect::Vanish]),
+                    (Id(2), vec![Effect::Vanish]),
                 ],
                 timed_effects: Vec::new(),
                 scheduled_abilities: Vec::new(),

--- a/src/core/battle/tests.rs
+++ b/src/core/battle/tests.rs
@@ -16,8 +16,13 @@ use crate::core::{
         movement::Path,
         scenario::{self, ExactObject, Scenario},
         state::BattleResult,
+<<<<<<< HEAD
         Accuracy, Attacks, Dodge, Id, Jokers, MovePoints, Moves, Phase, PlayerId, State,
         Strength, Weight
+=======
+        Accuracy, Attacks, Dodge, Id, Jokers, MovePoints, Moves, Phase, PlayerId, State, Strength,
+        Weight,
+>>>>>>> cargo fmt
     },
     map::{Dir, Distance, PosHex},
 };
@@ -121,9 +126,7 @@ fn component_strength(n: i32) -> Component {
 }
 
 fn component_blocker(w: Weight) -> Component {
-    component::Blocker {
-        weight: w,
-    }.into()
+    component::Blocker { weight: w }.into()
 }
 
 fn component_abilities(abilities: &[Ability]) -> Component {
@@ -1259,7 +1262,12 @@ fn throw_bomb_push() {
         ),
         (
             "weak",
-            [component_agent_dull(), component_strength(1), component_blocker(Weight::Normal)].to_vec(),
+            [
+                component_agent_dull(),
+                component_strength(1),
+                component_blocker(Weight::Normal),
+            ]
+            .to_vec(),
         ),
         ("bomb_push", Vec::new()),
     ]);

--- a/src/core/battle/tests.rs
+++ b/src/core/battle/tests.rs
@@ -253,6 +253,12 @@ fn ability_throw_bomb_push() -> Ability {
     }
     .into()
 }
+fn ability_knockback_normal() -> Ability {
+    ability::Knockback {
+        strength: PushStrength(Weight::Normal),
+    }
+    .into()
+}
 
 fn ability_club() -> Ability {
     Ability::Club
@@ -1432,12 +1438,134 @@ fn throw_bomb_push_heavy() {
                         Id(1),
                         vec![effect::Knockback {
                             from: PosHex { q: 1, r: 2 },
-                            to: PosHex { q: 2, r: 2 },
+                            to: PosHex { q: 1, r: 2 },
                             strength: PushStrength { 0: Weight::Normal },
                         }
                         .into()],
                     ),
                     (Id(2), vec![Effect::Vanish]),
+                ],
+                timed_effects: Vec::new(),
+                scheduled_abilities: Vec::new(),
+            },
+        ],
+    );
+    assert_eq!(state.parts().pos.get(Id(1)).0, initial_heavy_position);
+}
+#[test]
+fn knockback_normal_vs_normal() {
+    let prototypes = prototypes(&[
+        (
+            "knockbacker",
+            vec![
+                component_agent_one_attack(),
+                component_abilities(&[ability_knockback_normal()]),
+            ],
+        ),
+        (
+            "weak",
+            [
+                component_agent_dull(),
+                component_strength(1),
+                component_blocker(Weight::Normal),
+            ]
+            .to_vec(),
+        ),
+    ]);
+    let initial_weak_position = PosHex { q: 0, r: 3 };
+    let scenario = scenario::default()
+        .object(P0, "knockbacker", PosHex { q: 0, r: 2 })
+        .object(P1, "weak", initial_weak_position);
+    let mut state = debug_state(prototypes, scenario);
+    exec_and_check(
+        &mut state,
+        command::UseAbility {
+            id: Id(0),
+            pos: initial_weak_position,
+            ability: ability_knockback_normal(),
+        },
+        &[
+            Event {
+                active_event: event::UseAbility {
+                    id: Id(0),
+                    pos: initial_weak_position,
+                    ability: ability::Knockback {
+                        strength: PushStrength(Weight::Normal),
+                    }.into(),
+                }
+                .into(),
+                actor_ids: vec![Id(1), Id(0)],
+                instant_effects: vec![
+                    (
+                        Id(1),
+                        vec![effect::Knockback {
+                            from: initial_weak_position,
+                            to: PosHex { q: 0, r: 4 },
+                            strength: PushStrength { 0: Weight::Normal },
+                        }
+                        .into()],
+                    ),
+                ],
+                timed_effects: Vec::new(),
+                scheduled_abilities: Vec::new(),
+            },
+        ],
+    );
+    assert_eq!(state.parts().pos.get(Id(1)).0, PosHex { q: 0, r: 4 });
+}
+#[test]
+fn knockback_normal_vs_heavy() {
+    let prototypes = prototypes(&[
+        (
+            "knockbacker",
+            vec![
+                component_agent_one_attack(),
+                component_abilities(&[ability_knockback_normal()]),
+            ],
+        ),
+        (
+            "heavy",
+            [
+                component_agent_dull(),
+                component_strength(1),
+                component_blocker(Weight::Heavy),
+            ]
+            .to_vec(),
+        ),
+    ]);
+    let initial_heavy_position = PosHex { q: 0, r: 3 };
+    let scenario = scenario::default()
+        .object(P0, "knockbacker", PosHex { q: 0, r: 2 })
+        .object(P1, "heavy", initial_heavy_position);
+    let mut state = debug_state(prototypes, scenario);
+    exec_and_check(
+        &mut state,
+        command::UseAbility {
+            id: Id(0),
+            pos: initial_heavy_position,
+            ability: ability_knockback_normal(),
+        },
+        &[
+            Event {
+                active_event: event::UseAbility {
+                    id: Id(0),
+                    pos: initial_heavy_position,
+                    ability: ability::Knockback {
+                        strength: PushStrength(Weight::Normal),
+                    }.into(),
+                }
+                .into(),
+                actor_ids: vec![Id(1), Id(0)],
+                instant_effects: vec![
+                    (
+                        Id(1),
+                        vec![effect::Knockback {
+                            from: initial_heavy_position,
+                            to: initial_heavy_position,
+                            strength: PushStrength { 0: Weight::Normal },
+                        }
+                        .into()],
+                    ),
                 ],
                 timed_effects: Vec::new(),
                 scheduled_abilities: Vec::new(),

--- a/src/core/battle/tests.rs
+++ b/src/core/battle/tests.rs
@@ -425,11 +425,10 @@ fn kill_and_end_the_battle() {
     let prototypes = prototypes(&[
         (
             "swordsman",
-            [
+            vec![
                 component_agent_always_hit_strength_1(),
                 component_strength(1),
-            ]
-            .to_vec(),
+            ],
         ),
         (
             "imp",
@@ -1338,7 +1337,7 @@ fn throw_bomb_push_normal() {
                         vec![effect::Knockback {
                             from: PosHex { q: 0, r: 3 },
                             to: PosHex { q: 0, r: 4 },
-                            strength: PushStrength { 0: Weight::Normal },
+                            strength: PushStrength(Weight::Normal),
                         }
                         .into()],
                     ),
@@ -1351,6 +1350,7 @@ fn throw_bomb_push_normal() {
     );
     assert_eq!(state.parts().pos.get(Id(1)).0, PosHex { q: 0, r: 4 });
 }
+
 #[test]
 fn throw_bomb_push_heavy() {
     let prototypes = prototypes(&[
@@ -1439,7 +1439,7 @@ fn throw_bomb_push_heavy() {
                         vec![effect::Knockback {
                             from: PosHex { q: 1, r: 2 },
                             to: PosHex { q: 1, r: 2 },
-                            strength: PushStrength { 0: Weight::Normal },
+                            strength: PushStrength(Weight::Normal),
                         }
                         .into()],
                     ),
@@ -1452,6 +1452,7 @@ fn throw_bomb_push_heavy() {
     );
     assert_eq!(state.parts().pos.get(Id(1)).0, initial_heavy_position);
 }
+
 #[test]
 fn knockback_normal_vs_normal() {
     let prototypes = prototypes(&[
@@ -1510,6 +1511,7 @@ fn knockback_normal_vs_normal() {
     );
     assert_eq!(state.parts().pos.get(Id(1)).0, PosHex { q: 0, r: 4 });
 }
+
 #[test]
 fn knockback_normal_vs_heavy() {
     let prototypes = prototypes(&[
@@ -1558,7 +1560,7 @@ fn knockback_normal_vs_heavy() {
                 vec![effect::Knockback {
                     from: initial_heavy_position,
                     to: initial_heavy_position,
-                    strength: PushStrength { 0: Weight::Normal },
+                    strength: PushStrength(Weight::Normal),
                 }
                 .into()],
             )],

--- a/src/core/battle/tests.rs
+++ b/src/core/battle/tests.rs
@@ -16,7 +16,8 @@ use crate::core::{
         movement::Path,
         scenario::{self, ExactObject, Scenario},
         state::BattleResult,
-        Accuracy, Attacks, Dodge, Id, Jokers, MovePoints, Moves, Phase, PlayerId, State, Strength, PushStrength, Weight,
+        Accuracy, Attacks, Dodge, Id, Jokers, MovePoints, Moves, Phase, PlayerId, PushStrength,
+        State, Strength, Weight,
     },
     map::{Dir, Distance, PosHex},
 };

--- a/src/core/battle/tests.rs
+++ b/src/core/battle/tests.rs
@@ -1459,7 +1459,7 @@ fn knockback_normal_vs_normal() {
         (
             "knockbacker",
             vec![
-                component_agent_one_attack(),
+                component_agent_always_hit(),
                 component_abilities(&[ability_knockback_normal()]),
             ],
         ),
@@ -1518,7 +1518,7 @@ fn knockback_normal_vs_heavy() {
         (
             "knockbacker",
             vec![
-                component_agent_one_attack(),
+                component_agent_always_hit(),
                 component_abilities(&[ability_knockback_normal()]),
             ],
         ),

--- a/src/core/battle/tests.rs
+++ b/src/core/battle/tests.rs
@@ -1343,6 +1343,7 @@ fn throw_bomb_push_normal() {
             },
         ],
     );
+    assert_eq!(state.parts().pos.get(Id(1)).0, PosHex { q: 0, r: 4 });
 }
 #[test]
 fn throw_bomb_push_heavy() {
@@ -1359,15 +1360,16 @@ fn throw_bomb_push_heavy() {
             [
                 component_agent_dull(),
                 component_strength(1),
-                component_blocker(Weight::Normal),
+                component_blocker(Weight::Heavy),
             ]
             .to_vec(),
         ),
         ("bomb_push", Vec::new()),
     ]);
+    let initial_heavy_position = PosHex { q: 1, r: 2 };
     let scenario = scenario::default()
         .object(P0, "thrower", PosHex { q: 0, r: 0 })
-        .object(P1, "heavy", PosHex { q: 1, r: 2 });
+        .object(P1, "heavy", initial_heavy_position);
     let mut state = debug_state(prototypes, scenario);
     exec_and_check(
         &mut state,
@@ -1442,4 +1444,5 @@ fn throw_bomb_push_heavy() {
             },
         ],
     );
+    assert_eq!(state.parts().pos.get(Id(1)).0, initial_heavy_position);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,7 +102,7 @@ fn main() -> ZResult {
     const APP_ID: &str = "zemeroth";
     const APP_AUTHOR: &str = "ozkriff";
     const ASSETS_DIR_NAME: &str = "assets";
-    const ASSETS_HASHSUM: &str = "c6baaaf47a5aab1929e164a5b1abf364";
+    const ASSETS_HASHSUM: &str = "e88f751df539821f0e7e72b918170bcd";
 
     fn enable_backtrace() {
         if std::env::var("RUST_BACKTRACE").is_err() {

--- a/src/screen/agent_info.rs
+++ b/src/screen/agent_info.rs
@@ -99,6 +99,9 @@ impl AgentInfo {
             if let Some(strength) = info.strength {
                 line(&format!("strength: {}", strength.base_strength.0))?;
             }
+            if let Some(blocker) = info.blocker {
+                line(&format!("weight: {}", blocker.weight))?;
+            }
             if let Some(agent) = info.agent {
                 line(&format!("attacks: {}", agent.base_attacks.0))?;
                 line(&format!("moves: {}", agent.base_moves.0))?;

--- a/src/screen/battle.rs
+++ b/src/screen/battle.rs
@@ -81,6 +81,9 @@ fn build_panel_agent_info(
                 line(&format!("armor: {}", armor))?;
             }
         }
+        if let Some(blocker) = parts.blocker.get_opt(id) {
+            line(&format!("weight: {}", blocker.weight))?;
+        }
         if a.jokers.0 != 0 || a.base_jokers.0 != 0 {
             line(&format!("jokers: {}/{}", a.jokers.0, a.base_jokers.0))?;
         }

--- a/src/screen/battle/visualize.rs
+++ b/src/screen/battle/visualize.rs
@@ -1100,6 +1100,9 @@ fn visualize_effect_knockback(
     target_id: Id,
     effect: &effect::Knockback,
 ) -> ZResult<Box<dyn Action>> {
+    if effect.from == effect.to {
+        return message(view, context, effect.from, "Resisted knockback");
+    }
     let sprite = view.id_to_sprite(target_id).clone();
     let sprite_shadow = view.id_to_shadow_sprite(target_id).clone();
     let from = geom::hex_to_point(view.tile_size(), effect.from);

--- a/src/screen/battle/visualize.rs
+++ b/src/screen/battle/visualize.rs
@@ -1125,6 +1125,9 @@ fn visualize_effect_fly_off(
     target_id: Id,
     effect: &effect::FlyOff,
 ) -> ZResult<Box<dyn Action>> {
+    if effect.from == effect.to {
+        return message(view, context, effect.from, "Resisted fly off");
+    }
     let sprite_object = view.id_to_sprite(target_id).clone();
     let sprite_shadow = view.id_to_shadow_sprite(target_id).clone();
     let from = geom::hex_to_point(view.tile_size(), effect.from);


### PR DESCRIPTION
Related to https://github.com/ozkriff/zemeroth/issues/291

Impacts would only be "BombPush" ability used on ally Heavy agents.

Features:
- [x] Weight logic for BombPush
- [x] Same logic for FlyOff effect
- [x] Visualization for failed knockback
- [x] PR for assets/objects.ron definitions : https://github.com/ozkriff/zemeroth_assets/pull/6
- [x] Tests for Knockback
- [x] Tests for FlyOff