### PR TITLE
Travis: Disable "cargo test" on windows for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,9 @@ before_script:
 script:
   - cargo build --all
   - cargo build --examples --all
-  - cargo test --all
+  
+  # TODO: a workaround for https://github.com/ozkriff/zemeroth/issues/545
+  - if [ $TRAVIS_OS_NAME != "windows" ]; then cargo test --all; fi
 
 jobs:
   include:


### PR DESCRIPTION
This workaround should make Travis green again.

See https://users.rust-lang.org/t/weird-cargo-test-error-on-travis-windows-job/36800

Related to #545 (_"Fix Travis Builds: STATUS_DLL_NOT_FOUND"_)
