### PR TITLE
Add GitHub workflows for CI and Release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,30 @@ name: CI
 on: [pull_request, push]
 
 jobs:
-  lints:
-    name: Rustfmt and clippy
+  format:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: rustfmt
+          profile: minimal
+          override: true
+
+      - name: Run rustfmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+  clippy:
+    name: Clippy
     runs-on: ubuntu-latest
 
     steps:
@@ -20,15 +42,9 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-          components: clippy, rustfmt
+          components: clippy
           profile: minimal
           override: true
-
-      - name: Run rustfmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
 
       - name: Run clippy
         uses: actions-rs/clippy-check@v1
@@ -63,7 +79,6 @@ jobs:
 
   build:
     name: ${{ matrix.build }}
-    needs: [lints]
     runs-on: ${{ matrix.os }}
 
     # The build matrix does not yet support 'allow failures' at job level.
@@ -117,7 +132,6 @@ jobs:
 
   wasm:
     name: WASM
-    needs: [lints]
     runs-on: ubuntu-latest
 
     steps:
@@ -152,7 +166,6 @@ jobs:
 
   nightly:
     name: Nightly
-    needs: [lints]
     runs-on: ${{ matrix.os }}
 
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,30 +50,16 @@ jobs:
           repository: ozkriff/zemeroth_assets
           path: assets
 
-      - name: Install packages
-        run: |
-          sudo apt-get update
-          sudo apt-get -yq --no-install-suggests --no-install-recommends install libasound2-dev libudev-dev
-
-      - name: Install rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-
-      - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-
       - name: Check
-        uses: actions-rs/cargo@v1
-        env:
-          RUST_LOG: zemeroth=info
-        with:
-          command: run
-          args: -- --check-assets
+        run: |
+          SRC=$(grep "const ASSETS_HASHSUM" src/main.rs | cut -d\" -f 2)
+          ASSETS=$(cat assets/.checksum.md5)
+
+          echo "Source: $SRC"
+          echo "Assets: $ASSETS"
+          if [ "$SRC" != "$ASSETS" ]; then
+            false
+          fi
 
   build:
     name: ${{ matrix.build }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,207 @@
+name: CI
+
+on: [pull_request, push]
+
+jobs:
+  lints:
+    name: Rustfmt and clippy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install packages
+        run: |
+          sudo apt-get update
+          sudo apt-get -yq --no-install-suggests --no-install-recommends install libasound2-dev libudev-dev
+
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: clippy, rustfmt
+          profile: minimal
+          override: true
+
+      - name: Run rustfmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+      - name: Run clippy
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: -- -D warnings
+
+  assets:
+    name: Check assets
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Checkout assets
+        uses: actions/checkout@v2
+        with:
+          repository: ozkriff/zemeroth_assets
+          path: assets
+
+      - name: Install packages
+        run: |
+          sudo apt-get update
+          sudo apt-get -yq --no-install-suggests --no-install-recommends install libasound2-dev libudev-dev
+
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+
+      - name: Check
+        uses: actions-rs/cargo@v1
+        env:
+          RUST_LOG: zemeroth=info
+        with:
+          command: run
+          args: -- --check-assets
+
+  build:
+    name: ${{ matrix.build }}
+    needs: [lints]
+    runs-on: ${{ matrix.os }}
+
+    # The build matrix does not yet support 'allow failures' at job level.
+    # See `jobs.nightly` for the nightly job definition.
+    strategy:
+      matrix:
+        build: [Linux, macOS, Win32, Win64]
+
+        include:
+          - build: Linux
+            os: ubuntu-latest
+            packages: libasound2-dev libudev-dev
+          - build: macOS
+            os: macOS-latest
+          - build: Win32
+            os: windows-latest
+            rust: stable-i686-pc-windows-msvc
+            target: i686-pc-windows-msvc
+          - build: Win64
+            os: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install packages (Linux)
+        if: runner.os == 'Linux' && matrix.packages
+        run: |
+          sudo apt-get update
+          sudo apt-get -yq --no-install-suggests --no-install-recommends install ${{ matrix.packages }}
+
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust || 'stable' }}
+          target: ${{ matrix.target }}
+          profile: minimal
+          override: true
+
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --examples --all
+
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all
+
+  wasm:
+    name: WASM
+    needs: [lints]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: wasm32-unknown-unknown
+          profile: minimal
+          override: true
+
+      - name: Install cargo-web
+        run: |
+          CARGO_WEB_RELEASE=$(curl -L -s -H 'Accept: application/json' https://github.com/koute/cargo-web/releases/latest)
+          CARGO_WEB_VERSION=$(echo $CARGO_WEB_RELEASE | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
+          CARGO_WEB_HOST_TRIPLE="x86_64-unknown-linux-gnu"
+          CARGO_WEB_URL="https://github.com/koute/cargo-web/releases/download/$CARGO_WEB_VERSION/cargo-web-$CARGO_WEB_HOST_TRIPLE.gz"
+
+          echo "Downloading cargo-web from: $CARGO_WEB_URL"
+          curl -L $CARGO_WEB_URL | gzip -d > cargo-web
+          chmod +x cargo-web
+
+          mkdir -p ~/.cargo/bin
+          mv cargo-web ~/.cargo/bin
+
+      - name: Build
+        run: |
+          cargo web build
+
+  nightly:
+    name: Nightly
+    needs: [lints]
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+
+        include:
+          - os: ubuntu-latest
+            packages: libasound2-dev libudev-dev
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install packages (Linux)
+        if: runner.os == 'Linux' && matrix.packages
+        run: |
+          sudo apt-get update
+          sudo apt-get -yq --no-install-suggests --no-install-recommends install ${{ matrix.packages }}
+
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          override: true
+
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --examples --all
+
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,12 +194,14 @@ jobs:
           override: true
 
       - name: Build
+        continue-on-error: true
         uses: actions-rs/cargo@v1
         with:
           command: build
           args: --examples --all
 
       - name: Test
+        continue-on-error: true
         uses: actions-rs/cargo@v1
         with:
           command: test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,183 @@
+name: Release
+
+on: 
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        build: [linux, macos, win32, win64]
+
+        include:
+          - build: linux
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            bin: zemeroth
+            archive: .tar.gz
+            type: application/gzip
+          - build: macos
+            os: macOS-latest
+            target: x86_64-apple-darwin
+            bin: zemeroth
+            archive: .tar.gz
+            type: application/gzip
+          - build: win32
+            os: windows-latest
+            rust: stable-i686-pc-windows-msvc
+            target: i686-pc-windows-msvc
+            bin: zemeroth.exe
+            archive: .zip
+            type: application/zip
+          - build: win64
+            os: windows-latest
+            target: x86_64-pc-windows-msvc
+            bin: zemeroth.exe
+            archive: .zip
+            type: application/zip
+
+    steps:
+      - name: Install packages (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get -yq --no-install-suggests --no-install-recommends install libasound2-dev libudev-dev
+
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust || 'stable' }}
+          target: ${{ matrix.target }}
+          profile: minimal
+          override: true
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Checkout assets
+        uses: actions/checkout@v2
+        with:
+          repository: ozkriff/zemeroth_assets
+          path: assets
+
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --target ${{ matrix.target }}
+
+      - name: Package
+        id: package
+        shell: bash
+        env:
+          BUILD_NAME: ${{ matrix.build }}
+          ARCHIVE_EXT: ${{ matrix.archive }}
+        run: |
+          name=zemeroth
+          tag=$(git describe --tags --abbrev=0)
+          release_name="$name-$tag-$BUILD_NAME"
+          release_file="${release_name}${ARCHIVE_EXT}"
+          mkdir "$release_name"
+
+          if [ "${{ runner.os }}" = "Linux" ]; then
+            strip -s "target/${{ matrix.target }}/release/${{ matrix.bin }}"
+          elif [ "${{ runner.os }}" = "macOS" ]; then
+            strip "target/${{ matrix.target }}/release/${{ matrix.bin }}"
+          fi
+
+          cp target/${{ matrix.target }}/release/${{ matrix.bin }} "$release_name"
+          cp -r README.md assets "$release_name"
+          rm -rf "$release_name"/assets/.git
+
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            7z a "$release_file" "$release_name"
+          else
+            tar czvf "$release_file" "$release_name"
+          fi
+
+          echo "::set-output name=asset_name::$release_file"
+          echo "::set-output name=asset_path::$release_file"
+
+      - name: Upload
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_name: ${{ steps.package.outputs.asset_name }}
+          asset_path: ${{ steps.package.outputs.asset_path }}
+          asset_content_type: ${{ matrix.type }}
+
+  wasm:
+    name: build (web)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: wasm32-unknown-unknown
+          profile: minimal
+          override: true
+
+      - name: Install cargo-web
+        run: |
+          CARGO_WEB_RELEASE=$(curl -L -s -H 'Accept: application/json' https://github.com/koute/cargo-web/releases/latest)
+          CARGO_WEB_VERSION=$(echo $CARGO_WEB_RELEASE | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
+          CARGO_WEB_HOST_TRIPLE="x86_64-unknown-linux-gnu"
+          CARGO_WEB_URL="https://github.com/koute/cargo-web/releases/download/$CARGO_WEB_VERSION/cargo-web-$CARGO_WEB_HOST_TRIPLE.gz"
+
+          echo "Downloading cargo-web from: $CARGO_WEB_URL"
+          curl -L $CARGO_WEB_URL | gzip -d > cargo-web
+          chmod +x cargo-web
+
+          mkdir -p ~/.cargo/bin
+          mv cargo-web ~/.cargo/bin
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Checkout assets
+        uses: actions/checkout@v2
+        with:
+          repository: ozkriff/zemeroth_assets
+          path: assets
+
+      - name: Build
+        run: |
+          cargo web build --release
+
+      - name: Package
+        id: package
+        run: |
+          name=zemeroth
+          tag=$(git describe --tags --abbrev=0)
+          release_name="$name-$tag-web"
+          release_file="${release_name}.zip"
+          mkdir "$release_name"
+
+          cp target/wasm32-unknown-unknown/release/zemeroth.js "$release_name"
+          cp target/wasm32-unknown-unknown/release/zemeroth.wasm "$release_name"
+          cp README.md utils/wasm/index.html "$release_name"
+
+          ls assets | sed 's:^:/:' > "$release_name"/index.txt
+          find assets -type f -not -path '*/.git/*' -exec cp '{}' $release_name \;
+
+          7z a "$release_file" "$release_name"
+
+          echo "::set-output name=asset_name::$release_file"
+          echo "::set-output name=asset_path::$release_file"
+
+      - name: Upload
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_name: ${{ steps.package.outputs.asset_name }}
+          asset_path: ${{ steps.package.outputs.asset_path }}
+          asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,32 @@ on:
     types: [published]
 
 jobs:
+  assets:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Checkout assets
+        uses: actions/checkout@v2
+        with:
+          repository: ozkriff/zemeroth_assets
+          path: assets
+
+      - name: Check
+        run: |
+          SRC=$(grep "const ASSETS_HASHSUM" src/main.rs | cut -d\" -f 2)
+          ASSETS=$(cat assets/.checksum.md5)
+
+          echo "Source: $SRC"
+          echo "Assets: $ASSETS"
+          if [ "$SRC" != "$ASSETS" ]; then
+            false
+          fi
+
   build:
+    needs: [assets]
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -113,6 +138,7 @@ jobs:
 
   wasm:
     name: build (web)
+    needs: [assets]
     runs-on: ubuntu-latest
 
     steps:

--- a/README.md
+++ b/README.md
@@ -17,15 +17,18 @@ Zemeroth is a turn-based hexagonal tactical game written in [Rust].
 [devlog on imgur](https://imgur.com/a/SMVqO)
 
 **Status**:
+[![Github Actions][img_gh-actions]][gh-actions]
 [![travis status][img_travis-ci]][travis-ci]
 [![appveyor status][img_appveyor-ci]][appveyor-ci]
 [![dependency status][img_deps-rs]][deps-rs]
 
+[img_gh-actions]: https://github.com/ozkriff/zemeroth/workflows/CI/badge.svg
 [img_travis-ci]: https://img.shields.io/travis/com/ozkriff/zemeroth/master.svg?label=Linux|OSX
 [img_appveyor-ci]: https://img.shields.io/appveyor/ci/ozkriff/zemeroth/master.svg?label=Windows
 [img_deps-rs]: https://deps.rs/repo/github/ozkriff/zemeroth/status.svg
 
 [loc]: https://github.com/Aaronepower/tokei
+[gh-actions]: https://github.com/ozkriff/zemeroth/actions?query=workflow%3ACI
 [travis-ci]: https://travis-ci.com/ozkriff/zemeroth
 [appveyor-ci]: https://ci.appveyor.com/project/ozkriff/zemeroth
 [deps-rs]: https://deps.rs/repo/github/ozkriff/zemeroth


### PR DESCRIPTION
The CI workflow combines the Travis & Appveyor setup except for the release builds. 
These are moved into the Release workflow.

related: #543 