### PR TITLE
Remove warn(bare_trait_objects)

### DIFF
--- a/ggwp-zgui/src/lib.rs
+++ b/ggwp-zgui/src/lib.rs
@@ -1,5 +1,3 @@
-#![warn(bare_trait_objects)]
-
 #[cfg(not(target_arch = "wasm32"))]
 extern crate ggez;
 #[cfg(target_arch = "wasm32")]

--- a/ggwp-zscene/src/lib.rs
+++ b/ggwp-zscene/src/lib.rs
@@ -1,5 +1,3 @@
-#![warn(bare_trait_objects)]
-
 #[cfg(not(target_arch = "wasm32"))]
 extern crate ggez;
 #[cfg(target_arch = "wasm32")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
 #![windows_subsystem = "windows"]
-#![warn(bare_trait_objects)]
 
 #[cfg(not(target_arch = "wasm32"))]
 extern crate ggez;

--- a/zcomponents/src/lib.rs
+++ b/zcomponents/src/lib.rs
@@ -85,8 +85,6 @@
 //! assert!(!storage.is_exist(id0));
 //! ```
 
-#![warn(bare_trait_objects)]
-
 use std::{
     collections::{hash_map, HashMap},
     default::Default,


### PR DESCRIPTION
It's not needed in modern Rust.

Related to #293 (_"dyn trait + warn(bare_trait_objects)"_)