### PR TITLE
UI icons, ability descriptions, popups, and more

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,7 +442,7 @@ version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -461,7 +461,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -884,7 +884,7 @@ dependencies = [
 [[package]]
 name = "good-web-game"
 version = "0.2.5"
-source = "git+https://github.com/not-fl3/good-web-game#97ab68757b720ee2bf40de61ddd5423b9e33b429"
+source = "git+https://github.com/not-fl3/good-web-game#673bc64b2eaec6ee14fd42b0d68862779dad5cbd"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cgmath 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1511,7 +1511,7 @@ dependencies = [
  "proc-macro-error-attr 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1522,7 +1522,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn-mid 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1967,7 +1967,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2103,7 +2103,7 @@ dependencies = [
  "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2118,7 +2118,7 @@ dependencies = [
  "serde_derive 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2150,7 +2150,7 @@ dependencies = [
  "proc-macro-error 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2165,7 +2165,7 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2180,7 +2180,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2332,7 +2332,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-shared 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2352,7 +2352,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-backend 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-shared 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2775,7 +2775,7 @@ dependencies = [
 "checksum structopt 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)" = "c8faa2719539bbe9d77869bfb15d4ee769f99525e707931452c97b693b3f159d"
 "checksum structopt-derive 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3f88b8e18c69496aad6f9ddf4630dd7d585bcaf765786cb415b9aec2fe5a0430"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-"checksum syn 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)" = "123bd9499cfb380418d509322d7a6d52e5315f064fe4b3ad18a53d6b92c07859"
+"checksum syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03"
 "checksum syn-mid 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 "checksum tar 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)" = "b3196bfbffbba3e57481b6ea32249fbaf590396a52505a2615adbb79d9d826d3"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"

--- a/ggwp-zgui/README.md
+++ b/ggwp-zgui/README.md
@@ -16,7 +16,8 @@ Limitations:
 From simple to complicated:
 
 - [text_button.rs](./examples/text_button.rs)
-- [layout.rs](./examples/layout.rs)
+- [vertical_layout.rs](examples/vertical_layout.rs)
+- [layers_layout.rs](examples/layers_layout.rs)
 - [nested.rs](./examples/nested.rs)
 - [remove.rs](./examples/remove.rs)
 - [pixel_coordinates.rs](./examples/pixel_coordinates.rs)

--- a/ggwp-zgui/examples/absolute_coordinates.rs
+++ b/ggwp-zgui/examples/absolute_coordinates.rs
@@ -14,8 +14,8 @@ enum Message {
 
 fn make_gui(context: &mut Context, font: Font) -> ui::Result<ui::Gui<Message>> {
     let mut gui = ui::Gui::new(context);
-    let text_1 = Box::new(Text::new(("[Button1]", font, 32.0)));
-    let text_2 = Box::new(Text::new(("[Button1]", font, 64.0)));
+    let text_1 = Box::new(Text::new(("Button1", font, 32.0)));
+    let text_2 = Box::new(Text::new(("Button2", font, 64.0)));
     let button_1 = ui::Button::new(context, text_1, 0.2, gui.sender(), Message::Command1)?;
     let button_2 = ui::Button::new(context, text_2, 0.2, gui.sender(), Message::Command2)?;
     let mut layout = ui::VLayout::new();

--- a/ggwp-zgui/examples/layers_layout.rs
+++ b/ggwp-zgui/examples/layers_layout.rs
@@ -1,6 +1,6 @@
 use ggez::{
     conf, event,
-    graphics::{self, Font, Text},
+    graphics::{self, Font, Image, Text},
     nalgebra::Point2,
     Context, ContextBuilder, GameResult,
 };
@@ -9,17 +9,16 @@ use ggwp_zgui as ui;
 #[derive(Clone, Copy, Debug)]
 enum Message {
     Command1,
-    Command2,
 }
 
 fn make_gui(context: &mut Context, font: Font) -> ui::Result<ui::Gui<Message>> {
     let font_size = 64.0;
     let mut gui = ui::Gui::new(context);
-    let text_1 = Box::new(Text::new(("[Button1]", font, font_size)));
-    let text_2 = Box::new(Text::new(("[Button2]", font, font_size)));
-    let button_1 = ui::Button::new(context, text_1, 0.2, gui.sender(), Message::Command1)?;
-    let button_2 = ui::Button::new(context, text_2, 0.2, gui.sender(), Message::Command2)?;
-    let mut layout = ui::VLayout::new();
+    let text = Box::new(Text::new(("text", font, font_size)));
+    let image = Box::new(Image::new(context, "/fire.png")?);
+    let button_1 = ui::Button::new(context, image, 0.2, gui.sender(), Message::Command1)?;
+    let button_2 = ui::Label::new(context, text, 0.1)?;
+    let mut layout = ui::LayersLayout::new();
     layout.add(Box::new(button_1));
     layout.add(Box::new(button_2));
     let anchor = ui::Anchor(ui::HAnchor::Right, ui::VAnchor::Bottom);
@@ -56,10 +55,6 @@ impl event::EventHandler for State {
         graphics::present(context)
     }
 
-    fn resize_event(&mut self, context: &mut Context, w: f32, h: f32) {
-        self.resize(context, w, h);
-    }
-
     fn mouse_button_up_event(
         &mut self,
         context: &mut Context,
@@ -71,6 +66,10 @@ impl event::EventHandler for State {
         let pos = ui::window_to_screen(context, window_pos);
         let message = self.gui.click(pos);
         println!("[{},{}] -> {}: {:?}", x, y, pos, message);
+    }
+
+    fn resize_event(&mut self, context: &mut Context, w: f32, h: f32) {
+        self.resize(context, w, h);
     }
 }
 

--- a/ggwp-zgui/examples/nested.rs
+++ b/ggwp-zgui/examples/nested.rs
@@ -29,14 +29,14 @@ fn make_gui(context: &mut Context, font: Font) -> ui::Result<ui::Gui<Message>> {
     }
     {
         let text = Box::new(Text::new(("label", font, font_size)));
-        let label = ui::Label::new(context, text, 0.1)?;
+        let label = ui::Label::new_with_bg(context, text, 0.1)?;
         let anchor = ui::Anchor(ui::HAnchor::Left, ui::VAnchor::Bottom);
         gui.add(&ui::pack(label), anchor);
     }
     let v_layout_1 = {
-        let text_a = Box::new(Text::new(("[A]", font, font_size)));
-        let text_b = Box::new(Text::new(("[A]", font, font_size)));
-        let text_c = Box::new(Text::new(("[A]", font, font_size)));
+        let text_a = Box::new(Text::new(("A", font, font_size)));
+        let text_b = Box::new(Text::new(("A", font, font_size)));
+        let text_c = Box::new(Text::new(("A", font, font_size)));
         let button_a = ui::Button::new(context, text_a, 0.1, gui.sender(), Message::A)?;
         let button_b = ui::Button::new(context, text_b, 0.1, gui.sender(), Message::B)?;
         let button_c = ui::Button::new(context, text_c, 0.1, gui.sender(), Message::C)?;
@@ -48,9 +48,9 @@ fn make_gui(context: &mut Context, font: Font) -> ui::Result<ui::Gui<Message>> {
     };
     let v_layout_2 = {
         let image_i = Box::new(Image::new(context, "/fire.png")?);
-        let text_x = Box::new(Text::new(("[X]", font, font_size)));
-        let text_y = Box::new(Text::new(("[Y]", font, font_size)));
-        let text_z = Box::new(Text::new(("[Z]", font, font_size)));
+        let text_x = Box::new(Text::new(("X", font, font_size)));
+        let text_y = Box::new(Text::new(("Y", font, font_size)));
+        let text_z = Box::new(Text::new(("Z", font, font_size)));
         let button_i = ui::Button::new(context, image_i, 0.1, gui.sender(), Message::Image)?;
         let button_x = ui::Button::new(context, text_x, 0.1, gui.sender(), Message::X)?;
         let button_y = ui::Button::new(context, text_y, 0.1, gui.sender(), Message::Y)?;
@@ -63,8 +63,8 @@ fn make_gui(context: &mut Context, font: Font) -> ui::Result<ui::Gui<Message>> {
         layout
     };
     {
-        let text_a = Box::new(Text::new(("[A]", font, font_size)));
-        let text_b = Box::new(Text::new(("[A]", font, font_size)));
+        let text_a = Box::new(Text::new(("A", font, font_size)));
+        let text_b = Box::new(Text::new(("A", font, font_size)));
         let image_i = Box::new(Image::new(context, "/fire.png")?);
         let button_a = ui::Button::new(context, text_a, 0.1, gui.sender(), Message::A)?;
         let button_b = ui::Button::new(context, text_b, 0.1, gui.sender(), Message::B)?;

--- a/ggwp-zgui/examples/pixel_coordinates.rs
+++ b/ggwp-zgui/examples/pixel_coordinates.rs
@@ -14,8 +14,8 @@ enum Message {
 
 fn make_gui(context: &mut Context, font: Font) -> ui::Result<ui::Gui<Message>> {
     let mut gui = ui::Gui::new(context);
-    let text_1 = Box::new(Text::new(("[Button1]", font, 32.0)));
-    let text_2 = Box::new(Text::new(("[Button1]", font, 64.0)));
+    let text_1 = Box::new(Text::new(("Button1", font, 32.0)));
+    let text_2 = Box::new(Text::new(("Button1", font, 64.0)));
     let button_1 = ui::Button::new(context, text_1, 0.2, gui.sender(), Message::Command1)?;
     let button_2 = ui::Button::new(context, text_2, 0.2, gui.sender(), Message::Command2)?;
     let mut layout = ui::VLayout::new();

--- a/ggwp-zgui/examples/remove.rs
+++ b/ggwp-zgui/examples/remove.rs
@@ -13,14 +13,15 @@ enum Message {
 
 fn make_label(context: &mut Context) -> ui::Result<ui::RcWidget> {
     let image = Image::new(context, "/fire.png").expect("Can't load test image");
-    Ok(ui::pack(ui::Label::new(context, Box::new(image), 0.5)?))
+    let label = ui::Label::new_with_bg(context, Box::new(image), 0.5)?;
+    Ok(ui::pack(label))
 }
 
 fn make_gui(context: &mut Context, font: Font) -> ui::Result<ui::Gui<Message>> {
     let font_size = 32.0;
     let mut gui = ui::Gui::new(context);
     let anchor = ui::Anchor(ui::HAnchor::Right, ui::VAnchor::Bottom);
-    let text = Box::new(Text::new(("[Add/Remove]", font, font_size)));
+    let text = Box::new(Text::new(("Add/Remove", font, font_size)));
     let button = ui::Button::new(context, text, 0.2, gui.sender(), Message::AddOrRemove)?;
     gui.add(&ui::pack(button), anchor);
     Ok(gui)

--- a/ggwp-zgui/examples/vertical_layout.rs
+++ b/ggwp-zgui/examples/vertical_layout.rs
@@ -8,16 +8,22 @@ use ggwp_zgui as ui;
 
 #[derive(Clone, Copy, Debug)]
 enum Message {
-    Command,
+    Command1,
+    Command2,
 }
 
 fn make_gui(context: &mut Context, font: Font) -> ui::Result<ui::Gui<Message>> {
-    let font_size = 32.0;
+    let font_size = 64.0;
     let mut gui = ui::Gui::new(context);
+    let text_1 = Box::new(Text::new(("Button1", font, font_size)));
+    let text_2 = Box::new(Text::new(("Button2", font, font_size)));
+    let button_1 = ui::Button::new(context, text_1, 0.2, gui.sender(), Message::Command1)?;
+    let button_2 = ui::Button::new(context, text_2, 0.2, gui.sender(), Message::Command2)?;
+    let mut layout = ui::VLayout::new();
+    layout.add(Box::new(button_1));
+    layout.add(Box::new(button_2));
     let anchor = ui::Anchor(ui::HAnchor::Right, ui::VAnchor::Bottom);
-    let text = Box::new(Text::new(("Button", font, font_size)));
-    let button = ui::Button::new(context, text, 0.2, gui.sender(), Message::Command)?;
-    gui.add(&ui::pack(button), anchor);
+    gui.add(&ui::pack(layout), anchor);
     Ok(gui)
 }
 
@@ -57,7 +63,7 @@ impl event::EventHandler for State {
     fn mouse_button_up_event(
         &mut self,
         context: &mut Context,
-        _: event::MouseButton,
+        _: ggez::event::MouseButton,
         x: f32,
         y: f32,
     ) {

--- a/src/core/battle/ability.rs
+++ b/src/core/battle/ability.rs
@@ -1,9 +1,7 @@
-use std::fmt;
-
 use serde::{Deserialize, Serialize};
 
 use crate::core::{
-    battle::{Attacks, PushStrength, Strength},
+    battle::{Attacks, PushStrength, Strength, Weight},
     map::Distance,
 };
 
@@ -95,28 +93,94 @@ pub struct RechargeableAbility {
     pub base_cooldown: i32, // TODO: i32 -> Rounds
 }
 
-impl fmt::Display for Ability {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl Ability {
+    pub fn title(&self) -> String {
+        match self {
+            Ability::Knockback(a) => format!("Knockback ({})", a.strength.0),
+            Ability::Club => "Club".into(),
+            Ability::Jump(a) => format!("Jump ({})", (a.0).0),
+            Ability::Poison => "Poison".into(),
+            Ability::ExplodePush => "Explode Push".into(),
+            Ability::ExplodeDamage => "Explode Damage".into(),
+            Ability::ExplodeFire => "Explode Fire".into(),
+            Ability::ExplodePoison => "Explode Poison".into(),
+            Ability::Bomb(a) => format!("Bomb ({})", (a.0).0),
+            Ability::BombPush(a) => format!("Bomb Push ({})", a.throw_distance.0),
+            Ability::BombFire(a) => format!("Fire Bomb ({})", (a.0).0),
+            Ability::BombPoison(a) => format!("Poison Bomb ({})", (a.0).0),
+            Ability::BombDemonic(a) => format!("Demonic Bomb ({})", (a.0).0),
+            Ability::Vanish => "Vanish".into(),
+            Ability::Summon => "Summon".into(),
+            Ability::Dash => "Dash".into(),
+            Ability::Rage(a) => format!("Rage ({})", (a.0).0),
+            Ability::Heal(a) => format!("Heal ({})", (a.0).0),
+            Ability::Bloodlust => "Bloodlust".into(),
+        }
+    }
+
+    pub fn extended_description(&self) -> Vec<String> {
         match *self {
-            Ability::Knockback(a) => write!(f, "Knockback-{}", a.strength.0),
-            Ability::Club => write!(f, "Club"),
-            Ability::Jump(a) => write!(f, "Jump-{}", (a.0).0),
-            Ability::Poison => write!(f, "Poison"),
-            Ability::ExplodePush => write!(f, "Explode Push"),
-            Ability::ExplodeDamage => write!(f, "Explode Damage"),
-            Ability::ExplodeFire => write!(f, "Explode Fire"),
-            Ability::ExplodePoison => write!(f, "Explode Poison"),
-            Ability::Bomb(a) => write!(f, "Bomb-{}", (a.0).0),
-            Ability::BombPush(a) => write!(f, "Bomb Push-{}", (a.throw_distance).0),
-            Ability::BombFire(a) => write!(f, "Fire bomb-{}", (a.0).0),
-            Ability::BombPoison(a) => write!(f, "Poison bomb-{}", (a.0).0),
-            Ability::BombDemonic(a) => write!(f, "Bomb Demonic-{}", (a.0).0),
-            Ability::Vanish => write!(f, "Vanish"),
-            Ability::Summon => write!(f, "Summon"),
-            Ability::Dash => write!(f, "Dash"),
-            Ability::Rage(a) => write!(f, "Rage-{}", (a.0).0),
-            Ability::Heal(a) => write!(f, "Heal-{}", (a.0).0),
-            Ability::Bloodlust => write!(f, "Bloodlust"),
+            Ability::Knockback(a) => vec![
+                "Push an adjusted object one tile away.".into(),
+                format!("Can move objects with a weight up to {}.", a.strength.0),
+            ],
+            Ability::Club => vec!["Stun an adjusted agent for one turn.".into()],
+            Ability::Jump(a) => vec![
+                format!("Jump for up to {} tiles.", (a.0).0),
+                "Note: Triggers reaction attacks on landing.".into(),
+            ],
+            Ability::Bomb(a) => vec![
+                "Throw a bomb that explodes on the next turn.".into(),
+                "Damages all agents on the neighbour tiles.".into(),
+                format!("Can be thrown for up to {} tiles.", (a.0).0),
+            ],
+            Ability::BombPush(a) => vec![
+                "Throw a bomb that explodes *instantly*.".into(),
+                "Pushes all agents on the neighbour tiles.".into(),
+                format!("Can be thrown for up to {} tiles.", a.throw_distance.0),
+                format!("Can move objects with a weight up to {}.", Weight::Normal),
+            ],
+            Ability::BombFire(a) => vec![
+                "Throw a bomb that explodes on the next turn.".into(),
+                "Creates 7 fires.".into(),
+                format!("Can be thrown for up to {} tiles.", (a.0).0),
+            ],
+            Ability::BombPoison(a) => vec![
+                "Throw a bomb that explodes on the next turn.".into(),
+                "Creates 7 poison clouds.".into(),
+                format!("Can be thrown for up to {} tiles.", (a.0).0),
+            ],
+            Ability::BombDemonic(a) => vec![
+                "Throw a demonic bomb".into(),
+                "that explodes on the next turn.".into(),
+                "Damages all agents on the neighbour tiles.".into(),
+                format!("Can be thrown for up to {} tiles.", (a.0).0),
+            ],
+            Ability::Dash => vec![
+                "Move one tile".into(),
+                "without triggering any reaction attacks.".into(),
+            ],
+            Ability::Rage(a) => vec![format!("Instantly receive {} additional attacks.", (a.0).0)],
+            Ability::Heal(a) => vec![
+                format!("Heal {} strength points.", (a.0).0),
+                "Also, removes 'Poison' and 'Stun' lasting effects.".into(),
+            ],
+            Ability::Summon => vec![
+                "Summon a few lesser daemons.".into(),
+                "The number of summoned daemons increases".into(),
+                "by one with every use (up to six).".into(),
+            ],
+            Ability::Bloodlust => vec![
+                "Cast the 'Bloodlust' lasting effect on a friendly agent.".into(),
+                "This agent will receive three additional Jokers".into(),
+                "for a few turns.".into(),
+            ],
+            Ability::Poison
+            | Ability::Vanish
+            | Ability::ExplodePush
+            | Ability::ExplodeDamage
+            | Ability::ExplodeFire
+            | Ability::ExplodePoison => vec!["<internal ability>".into()],
         }
     }
 }
@@ -124,7 +188,7 @@ impl fmt::Display for Ability {
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 pub enum PassiveAbility {
     HeavyImpact,
-    SpawnPoisonCloudOnDeath,
+    SpawnPoisonCloudOnDeath, // TODO: implement and employ it!
     Burn,
     Poison,
     SpikeTrap,
@@ -135,16 +199,43 @@ pub enum PassiveAbility {
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Regenerate(pub Strength);
 
-impl fmt::Display for PassiveAbility {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl PassiveAbility {
+    pub fn title(self) -> String {
         match self {
-            PassiveAbility::HeavyImpact => write!(f, "Heavy impact"),
-            PassiveAbility::SpawnPoisonCloudOnDeath => write!(f, "Spawn a poison cloud on death"),
-            PassiveAbility::Burn => write!(f, "Burn"),
-            PassiveAbility::Poison => write!(f, "Poison"),
-            PassiveAbility::SpikeTrap => write!(f, "SpikeTrap"),
-            PassiveAbility::PoisonAttack => write!(f, "Poison attack"),
-            PassiveAbility::Regenerate(a) => write!(f, "Regenerate-{}", (a.0).0),
+            PassiveAbility::HeavyImpact => "Heavy Impact".into(),
+            PassiveAbility::SpawnPoisonCloudOnDeath => "Spawn Poison Cloud on Death".into(),
+            PassiveAbility::Burn => "Burn".into(),
+            PassiveAbility::Poison => "Poison".into(),
+            PassiveAbility::SpikeTrap => "Spike Trap".into(),
+            PassiveAbility::PoisonAttack => "Poison Attack".into(),
+            PassiveAbility::Regenerate(a) => format!("Regenerate ({})", (a.0).0),
+        }
+    }
+
+    pub fn extended_description(self) -> Vec<String> {
+        match self {
+            PassiveAbility::HeavyImpact => vec![
+                "Regular attack throws target one tile away.".into(),
+                format!(
+                    "Works on targets with a weight for up to {}.",
+                    Weight::Normal
+                ),
+            ],
+            PassiveAbility::SpawnPoisonCloudOnDeath => vec!["Not implemented yet.".into()],
+            PassiveAbility::Burn => {
+                vec!["Damages agents that enter into or begin their turn in the same tile.".into()]
+            }
+            PassiveAbility::Poison => {
+                vec!["Poisons agents that enter into or begin their turn in the same tile.".into()]
+            }
+            PassiveAbility::SpikeTrap => {
+                vec!["Damages agents that enter into or begin their turn in the same tile.".into()]
+            }
+            PassiveAbility::PoisonAttack => vec!["Regular attack poisons target.".into()],
+            PassiveAbility::Regenerate(a) => vec![format!(
+                "Regenerates {} strength points every turn.",
+                (a.0).0
+            )],
         }
     }
 }

--- a/src/core/battle/scenario.rs
+++ b/src/core/battle/scenario.rs
@@ -14,6 +14,12 @@ use crate::core::{
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum BattleType {
+    Skirmish,
+    CampaignNode,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ObjectsGroup {
     pub owner: Option<PlayerId>,
     pub typename: ObjType,

--- a/src/core/battle/state.rs
+++ b/src/core/battle/state.rs
@@ -1,6 +1,9 @@
 use crate::core::{
     battle::{
-        ability::PassiveAbility, component::ObjType, effect, Id, PlayerId, Strength, TileType,
+        self,
+        ability::{self, Ability, PassiveAbility},
+        component::ObjType,
+        effect, Id, PlayerId, Strength, TileType,
     },
     map::{self, PosHex},
     utils,
@@ -183,4 +186,16 @@ pub fn players_agent_types(state: &State, player_id: PlayerId) -> Vec<ObjType> {
         .into_iter()
         .map(|id| state.parts().meta.get(id).name.clone())
         .collect()
+}
+
+pub fn can_agent_use_ability(state: &State, id: Id, ability: &Ability) -> bool {
+    let parts = state.parts();
+    let agent_player_id = parts.belongs_to.get(id).0;
+    let agent = parts.agent.get(id);
+    let has_actions = agent.attacks > battle::Attacks(0) || agent.jokers > battle::Jokers(0);
+    let is_player_agent = agent_player_id == state.player_id();
+    let abilities = &parts.abilities.get(id).0;
+    let r_ability = abilities.iter().find(|r| &r.ability == ability).unwrap();
+    let is_ready = r_ability.status == ability::Status::Ready;
+    is_player_agent && is_ready && has_actions
 }

--- a/src/core/campaign.rs
+++ b/src/core/campaign.rs
@@ -24,6 +24,8 @@ pub enum Mode {
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, derive_more::From)]
 pub struct Renown(pub i32);
 
+// TODO: impl `Add` and `Sub` traits for `Renown`.
+
 /// An award that is given to the player after the successful battle.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct Award {

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ struct MainState {
 impl MainState {
     fn new(context: &mut Context) -> ZResult<Self> {
         let start_screen = Box::new(screen::MainMenu::new(context)?);
-        let screens = screen::Screens::new(start_screen);
+        let screens = screen::Screens::new(context, start_screen)?;
         let mut this = Self { screens };
         {
             let (w, h) = graphics::drawable_size(context);
@@ -41,7 +41,9 @@ impl MainState {
         let aspect_ratio = w / h;
         let coordinates = Rect::new(-aspect_ratio, -1.0, aspect_ratio * 2.0, 2.0);
         graphics::set_screen_coordinates(context, coordinates).expect("Can't resize the window");
-        self.screens.resize(aspect_ratio);
+        self.screens
+            .resize(context, aspect_ratio)
+            .expect("Can't resize screens");
     }
 }
 
@@ -102,7 +104,7 @@ fn main() -> ZResult {
     const APP_ID: &str = "zemeroth";
     const APP_AUTHOR: &str = "ozkriff";
     const ASSETS_DIR_NAME: &str = "assets";
-    const ASSETS_HASHSUM: &str = "e88f751df539821f0e7e72b918170bcd";
+    const ASSETS_HASHSUM: &str = "cf0e1e21e434c36e1d896d6c26b03204";
 
     fn enable_backtrace() {
         if std::env::var("RUST_BACKTRACE").is_err() {

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -1,29 +1,42 @@
 use log::info;
 use std::{fmt::Debug, time::Duration};
 
-use ggez::{self, graphics, Context};
+use ggez::{
+    self,
+    graphics::{self, Color},
+    Context,
+};
 use nalgebra::Point2;
 
 use crate::ZResult;
 
+mod ability_info;
 mod agent_info;
 mod battle;
 mod campaign;
+mod confirm;
 mod main_menu;
 
-pub use self::{agent_info::AgentInfo, battle::Battle, campaign::Campaign, main_menu::MainMenu};
+pub use self::{
+    ability_info::AbilityInfo, agent_info::AgentInfo, battle::Battle, campaign::Campaign,
+    confirm::Confirm, main_menu::MainMenu,
+};
+
+const COLOR_SCREEN_BG: Color = Color::new(0.9, 0.9, 0.8, 1.0);
+const COLOR_POPUP_BG: Color = Color::new(0.9, 0.9, 0.8, 0.8);
 
 #[derive(Debug)]
-pub enum Transition {
+pub enum StackCommand {
     None,
-    Push(Box<dyn Screen>),
+    PushScreen(Box<dyn Screen>),
+    PushPopup(Box<dyn Screen>),
     Pop,
 }
 
 pub trait Screen: Debug {
-    fn update(&mut self, context: &mut Context, dtime: Duration) -> ZResult<Transition>;
+    fn update(&mut self, context: &mut Context, dtime: Duration) -> ZResult<StackCommand>;
     fn draw(&self, context: &mut Context) -> ZResult;
-    fn click(&mut self, context: &mut Context, pos: Point2<f32>) -> ZResult<Transition>;
+    fn click(&mut self, context: &mut Context, pos: Point2<f32>) -> ZResult<StackCommand>;
     fn resize(&mut self, aspect_ratio: f32);
 
     fn move_mouse(&mut self, _context: &mut Context, _pos: Point2<f32>) -> ZResult {
@@ -31,75 +44,125 @@ pub trait Screen: Debug {
     }
 }
 
-const ERR_MSG: &str = "Screen stack is empty";
+const ERR_MSG_STACK_EMPTY: &str = "Screen stack is empty";
+
+struct ScreenWithPopups {
+    screen: Box<dyn Screen>,
+    popups: Vec<Box<dyn Screen>>,
+}
+
+impl ScreenWithPopups {
+    fn new(screen: Box<dyn Screen>) -> Self {
+        Self {
+            screen,
+            popups: Vec::new(),
+        }
+    }
+
+    fn top_mut(&mut self) -> &mut dyn Screen {
+        match self.popups.last_mut() {
+            Some(popup) => popup.as_mut(),
+            None => self.screen.as_mut(),
+        }
+    }
+}
+
+fn make_popup_bg_mesh(context: &mut Context) -> ZResult<graphics::Mesh> {
+    let coords = graphics::screen_coordinates(context);
+    let mode = graphics::DrawMode::fill();
+    Ok(graphics::Mesh::new_rectangle(
+        context,
+        mode,
+        coords,
+        COLOR_POPUP_BG,
+    )?)
+}
 
 pub struct Screens {
-    screens: Vec<Box<dyn Screen>>,
+    screens: Vec<ScreenWithPopups>,
+    popup_bg_mesh: graphics::Mesh,
 }
 
 impl Screens {
-    pub fn new(start_screen: Box<dyn Screen>) -> Self {
-        Self {
-            screens: vec![start_screen],
-        }
+    pub fn new(context: &mut Context, start_screen: Box<dyn Screen>) -> ZResult<Self> {
+        Ok(Self {
+            screens: vec![ScreenWithPopups::new(start_screen)],
+            popup_bg_mesh: make_popup_bg_mesh(context)?,
+        })
     }
 
     pub fn update(&mut self, context: &mut Context) -> ZResult {
         let dtime = ggez::timer::delta(context);
-        let command = self.screen_mut().update(context, dtime)?;
+        let command = self.screen_mut().top_mut().update(context, dtime)?;
         self.handle_command(context, command)
     }
 
     pub fn draw(&self, context: &mut Context) -> ZResult {
-        let bg_color = [0.9, 0.9, 0.8, 1.0].into();
-        graphics::clear(context, bg_color);
-        self.screen().draw(context)?;
+        graphics::clear(context, COLOR_SCREEN_BG);
+        let screen = self.screen();
+        screen.screen.draw(context)?;
+        for popup in &screen.popups {
+            graphics::draw(context, &self.popup_bg_mesh, graphics::DrawParam::default())?;
+            popup.draw(context)?;
+        }
         graphics::present(context)?;
         Ok(())
     }
 
     pub fn click(&mut self, context: &mut Context, pos: Point2<f32>) -> ZResult {
-        let command = self.screen_mut().click(context, pos)?;
+        let command = self.screen_mut().top_mut().click(context, pos)?;
         self.handle_command(context, command)
     }
 
     pub fn move_mouse(&mut self, context: &mut Context, pos: Point2<f32>) -> ZResult {
-        self.screen_mut().move_mouse(context, pos)
+        self.screen_mut().top_mut().move_mouse(context, pos)
     }
 
-    pub fn resize(&mut self, aspect_ratio: f32) {
+    pub fn resize(&mut self, context: &mut Context, aspect_ratio: f32) -> ZResult {
+        self.popup_bg_mesh = make_popup_bg_mesh(context)?;
         for screen in &mut self.screens {
-            screen.resize(aspect_ratio);
+            screen.screen.resize(aspect_ratio);
+            for popup in &mut screen.popups {
+                popup.resize(aspect_ratio);
+            }
         }
+        Ok(())
     }
 
-    pub fn handle_command(&mut self, context: &mut Context, command: Transition) -> ZResult {
+    pub fn handle_command(&mut self, context: &mut Context, command: StackCommand) -> ZResult {
         match command {
-            Transition::None => {}
-            Transition::Push(screen) => {
-                info!("Screens::handle_command: Push");
-                self.screens.push(screen);
+            StackCommand::None => {}
+            StackCommand::PushScreen(screen) => {
+                info!("Screens::handle_command: PushScreen");
+                self.screens.push(ScreenWithPopups::new(screen));
             }
-            Transition::Pop => {
+            StackCommand::Pop => {
                 info!("Screens::handle_command: Pop");
-                if self.screens.len() > 1 {
-                    self.screens.pop().expect(ERR_MSG);
+                let popups = &mut self.screen_mut().popups;
+                if !popups.is_empty() {
+                    popups.pop().expect(ERR_MSG_STACK_EMPTY);
+                } else if self.screens.len() > 1 {
+                    self.screens.pop().expect(ERR_MSG_STACK_EMPTY);
                 } else {
                     #[cfg(not(target_arch = "wasm32"))] // we can't quit wasm anyway
                     ggez::event::quit(context);
                 }
+            }
+            StackCommand::PushPopup(screen) => {
+                info!("Screens::handle_command: PushPopup");
+                self.screen_mut().popups.push(screen);
             }
         }
         Ok(())
     }
 
     /// Returns a mutable reference to the top screen.
-    fn screen_mut(&mut self) -> &mut dyn Screen {
-        self.screens.last_mut().expect(ERR_MSG).as_mut()
+    fn screen_mut(&mut self) -> &mut ScreenWithPopups {
+        self.screens.last_mut().expect(ERR_MSG_STACK_EMPTY)
     }
 
     /// Returns a reference to the top screen.
-    fn screen(&self) -> &dyn Screen {
-        self.screens.last().expect(ERR_MSG).as_ref()
+    fn screen(&self) -> &ScreenWithPopups {
+        self.screens.last().expect(ERR_MSG_STACK_EMPTY)
     }
 }

--- a/src/screen/ability_info.rs
+++ b/src/screen/ability_info.rs
@@ -1,0 +1,100 @@
+use std::time::Duration;
+
+use ggez::{
+    graphics::{self, Text},
+    Context,
+};
+use nalgebra::Point2;
+use ui::{self, Gui};
+
+use crate::{
+    core::battle::ability::{Ability, PassiveAbility},
+    screen::{Screen, StackCommand},
+    utils, ZResult,
+};
+
+#[derive(Clone, Debug)]
+enum Message {
+    Back,
+}
+
+pub enum ActiveOrPassiveAbility {
+    Active(Ability),
+    Passive(PassiveAbility),
+}
+
+#[derive(Debug)]
+pub struct AbilityInfo {
+    font: graphics::Font,
+    gui: Gui<Message>,
+}
+
+impl AbilityInfo {
+    pub fn new(context: &mut Context, ability: ActiveOrPassiveAbility) -> ZResult<Self> {
+        let font = utils::default_font(context);
+        let mut gui = ui::Gui::new(context);
+        let h = utils::line_heights().big;
+        let font_size = utils::font_size();
+        let mut layout = ui::VLayout::new();
+        let mut label = |text: &str| -> ZResult<Box<dyn ui::Widget>> {
+            let text = Box::new(Text::new((text, font, font_size)));
+            Ok(Box::new(ui::Label::new(context, text, h)?))
+        };
+        let spacer = || Box::new(ui::Spacer::new_vertical(h * 0.5));
+        let mut add = |w| layout.add(w);
+        match ability {
+            ActiveOrPassiveAbility::Active(ability) => {
+                add(label(&ability.title())?);
+                add(spacer());
+                for line in ability.extended_description() {
+                    add(label(&line)?);
+                }
+            }
+            ActiveOrPassiveAbility::Passive(ability) => {
+                add(label(&ability.title())?);
+                add(spacer());
+                for line in ability.extended_description() {
+                    add(label(&line)?);
+                }
+            }
+        }
+        add(spacer());
+        {
+            let text = Box::new(Text::new(("back", font, font_size)));
+            let button = ui::Button::new(context, text, h, gui.sender(), Message::Back)?;
+            add(Box::new(button));
+        }
+        let layout = utils::wrap_widget_and_add_bg(context, Box::new(layout))?;
+        let anchor = ui::Anchor(ui::HAnchor::Middle, ui::VAnchor::Middle);
+        gui.add(&ui::pack(layout), anchor);
+        Ok(Self { font, gui })
+    }
+}
+
+impl Screen for AbilityInfo {
+    fn update(&mut self, _context: &mut Context, _dtime: Duration) -> ZResult<StackCommand> {
+        Ok(StackCommand::None)
+    }
+
+    fn draw(&self, context: &mut Context) -> ZResult {
+        self.gui.draw(context)?;
+        Ok(())
+    }
+
+    fn click(&mut self, _: &mut Context, pos: Point2<f32>) -> ZResult<StackCommand> {
+        let message = self.gui.click(pos);
+        match message {
+            Some(Message::Back) => Ok(StackCommand::Pop),
+            None => Ok(StackCommand::None),
+        }
+    }
+
+    fn resize(&mut self, aspect_ratio: f32) {
+        self.gui.resize(aspect_ratio);
+    }
+
+    fn move_mouse(&mut self, _context: &mut Context, pos: Point2<f32>) -> ZResult {
+        self.gui.move_mouse(pos);
+        Ok(())
+    }
+}

--- a/src/screen/battle.rs
+++ b/src/screen/battle.rs
@@ -1,4 +1,7 @@
-use std::{sync::mpsc::Sender, time::Duration};
+use std::{
+    sync::mpsc::{channel, Receiver, Sender},
+    time::Duration,
+};
 
 use ggez::{
     graphics::{self, Font, Text},
@@ -13,7 +16,7 @@ use crate::{
     core::{
         battle::{
             self,
-            ability::{self, Ability},
+            ability::{self, Ability, PassiveAbility},
             ai::Ai,
             check, command,
             component::Prototypes,
@@ -27,15 +30,18 @@ use crate::{
     },
     geom,
     screen::{
+        self,
         battle::{
             view::{make_action_create_map, BattleView, SelectionMode},
             visualize::{fork, visualize},
         },
-        Screen, Transition,
+        Screen, StackCommand,
     },
     utils::{self, default_font, line_heights, time_s},
     ZResult,
 };
+
+// TODO: Don't use graphics::Image::new in this file! Pre-load all images into View.
 
 mod view;
 mod visualize;
@@ -45,9 +51,9 @@ const FONT_SIZE: f32 = utils::font_size();
 #[derive(Clone, Debug)]
 enum Message {
     Exit,
-    Deselect,
     EndTurn,
     Ability(Ability),
+    PassiveAbilityInfo(PassiveAbility),
 }
 
 fn build_panel_agent_info(
@@ -64,143 +70,228 @@ fn build_panel_agent_info(
     let mut layout = ui::VLayout::new();
     let h = line_heights().normal;
     {
-        let mut line = |text: &str| -> ZResult {
+        let label = |context: &mut Context, text: &str| -> ZResult<Box<dyn ui::Widget>> {
             let text = Box::new(Text::new((text, font, FONT_SIZE)));
-            let button = ui::Label::new(context, text, h)?;
-            layout.add(Box::new(button));
+            Ok(Box::new(ui::Label::new(context, text, h)?))
+        };
+        let mut add = |w| layout.add(w);
+        let mut line = |context: &mut Context, text: &str| -> ZResult {
+            add(label(context, text)?);
             Ok(())
         };
-        line(&format!("<{}>", meta.name.0))?;
-        line(&format!(
-            "strength: {}/{}",
-            st.strength.0, st.base_strength.0
-        ))?;
+        line(context, &format!("<{}>", meta.name.0))?;
+        line(
+            context,
+            &format!("strength: {}/{}", st.strength.0, st.base_strength.0),
+        )?;
         if let Some(armor) = parts.armor.get_opt(id) {
             let armor = armor.armor.0;
             if armor != 0 {
-                line(&format!("armor: {}", armor))?;
+                line(context, &format!("armor: {}", armor))?;
             }
         }
         if let Some(blocker) = parts.blocker.get_opt(id) {
-            line(&format!("weight: {}", blocker.weight))?;
+            line(context, &format!("weight: {}", blocker.weight))?;
         }
         if a.jokers.0 != 0 || a.base_jokers.0 != 0 {
-            line(&format!("jokers: {}/{}", a.jokers.0, a.base_jokers.0))?;
+            line(
+                context,
+                &format!("jokers: {}/{}", a.jokers.0, a.base_jokers.0),
+            )?;
         }
-        line(&format!("attacks: {}/{}", a.attacks.0, a.base_attacks.0))?;
+        line(
+            context,
+            &format!("attacks: {}/{}", a.attacks.0, a.base_attacks.0),
+        )?;
         if a.reactive_attacks.0 != 0 {
-            line(&format!("reactive attacks: {}", a.reactive_attacks.0))?;
+            line(
+                context,
+                &format!("reactive attacks: {}", a.reactive_attacks.0),
+            )?;
         }
-        line(&format!("moves: {}/{}", a.moves.0, a.base_moves.0))?;
-        if a.reactive_attacks.0 != 0 {
-            line(&format!("reactive attacks: {}", a.reactive_attacks.0))?;
-        }
+        line(context, &format!("moves: {}/{}", a.moves.0, a.base_moves.0))?;
         if a.attack_distance.0 != 1 {
-            line(&format!("attack distance: {}", a.attack_distance.0))?;
+            line(
+                context,
+                &format!("attack distance: {}", a.attack_distance.0),
+            )?;
         }
-        line(&format!("attack strength: {}", a.attack_strength.0))?;
-        line(&format!("attack accuracy: {}", a.attack_accuracy.0))?;
+        line(
+            context,
+            &format!("attack strength: {}", a.attack_strength.0),
+        )?;
+        line(
+            context,
+            &format!("attack accuracy: {}", a.attack_accuracy.0),
+        )?;
         if a.attack_break.0 > 0 {
-            line(&format!("armor break: {}", a.attack_break.0))?;
+            line(context, &format!("armor break: {}", a.attack_break.0))?;
         }
         if a.dodge.0 > 0 {
-            line(&format!("dodge: {}", a.dodge.0))?;
+            line(context, &format!("dodge: {}", a.dodge.0))?;
         }
-        line(&format!("move points: {}", a.move_points.0))?;
+        line(context, &format!("move points: {}", a.move_points.0))?;
         if let Some(abilities) = parts.passive_abilities.get_opt(id) {
             if !abilities.0.is_empty() {
-                line("<passive abilities>:")?;
-                for ability in &abilities.0 {
-                    line(&format!("'{}'", ability.to_string()))?;
+                line(context, "<passive abilities>:")?;
+                for &ability in &abilities.0 {
+                    let text = format!("'{}'", ability.title());
+                    let mut line_layout = ui::HLayout::new();
+                    line_layout.add(label(context, &text)?);
+                    let icon = Box::new(graphics::Image::new(context, "/icon_info.png")?);
+                    let message = Message::PassiveAbilityInfo(ability);
+                    let button = ui::Button::new(context, icon, h, gui.sender(), message)?;
+                    line_layout.add(Box::new(button));
+                    add(Box::new(line_layout));
                 }
             }
         }
-        if let Some(abilities) = parts.abilities.get_opt(id) {
-            if !abilities.0.is_empty() {
-                line("<abilities>:")?;
-                for ability in &abilities.0 {
-                    let s = ability.ability.to_string();
-                    line(&format!("'{}'", s))?;
-                }
-            }
-        }
+        // TODO: add (i) buttons for effects
         if let Some(effects) = parts.effects.get_opt(id) {
             if !effects.0.is_empty() {
-                line("<effects>:")?;
+                add(label(context, "<effects>:")?);
                 for effect in &effects.0 {
                     let s = effect.effect.to_str();
-                    match effect.duration {
-                        effect::Duration::Forever => line(&format!("'{}'", s))?,
-                        effect::Duration::Rounds(n) => line(&format!("'{}' ({})", s, n))?,
-                    }
+                    let text = match effect.duration {
+                        effect::Duration::Forever => format!("'{}'", s),
+                        effect::Duration::Rounds(n) => format!("'{}' ({})", s, n),
+                    };
+                    add(label(context, &text)?);
                 }
             }
         }
     }
-    let layout = ui::pack(layout);
+    let packed_layout = ui::pack(utils::wrap_widget_and_add_bg(context, Box::new(layout))?);
     let anchor = ui::Anchor(ui::HAnchor::Left, ui::VAnchor::Bottom);
-    gui.add(&layout, anchor);
-    Ok(layout)
+    gui.add(&packed_layout, anchor);
+    Ok(packed_layout)
 }
 
 fn build_panel_agent_abilities(
     context: &mut Context,
+    _view: &BattleView, // TODO: use this for cloning stored icon images
     font: Font,
     gui: &mut Gui<Message>,
     state: &State,
     id: Id,
+    mode: &SelectionMode,
 ) -> ZResult<Option<ui::RcWidget>> {
     let parts = state.parts();
     let abilities = match parts.abilities.get_opt(id) {
         Some(abilities) => &abilities.0,
         None => return Ok(None),
     };
-    let agent = parts.agent.get(id);
-    if agent.attacks <= battle::Attacks(0) && agent.jokers <= battle::Jokers(0) {
-        return Ok(None);
-    }
     let mut layout = ui::VLayout::new();
-    let h = line_heights().normal;
+    let h = line_heights().large;
     for ability in abilities {
-        let text = match ability.status {
-            ability::Status::Ready => format!("[{}]", ability.ability.to_string()),
-            ability::Status::Cooldown(n) => format!("[{} ({})]", ability.ability.to_string(), n),
+        let image_path = match ability.ability {
+            // TODO: load all the images only once. Store them in some struct and only clone them here.
+            // TODO: Move into view::Images!
+            Ability::Club => "/icon_ability_club.png",
+            Ability::Knockback(_) => "/icon_ability_knockback.png",
+            Ability::Jump(_) => "/icon_ability_jump.png",
+            Ability::Dash => "/icon_ability_dash.png",
+            Ability::Rage(_) => "/icon_ability_rage.png",
+            Ability::Heal(_) => "/icon_ability_heal.png",
+            Ability::BombPush(_) => "/icon_ability_bomb_push.png",
+            Ability::Bomb(_) => "/icon_ability_bomb.png",
+            Ability::BombFire(_) => "/icon_ability_bomb_fire.png",
+            Ability::BombPoison(_) => "/icon_ability_bomb_poison.png",
+            Ability::BombDemonic(_) => "/icon_ability_bomb_demonic.png",
+            Ability::Summon => "/icon_ability_summon.png",
+            Ability::Bloodlust => "/icon_ability_bloodlust.png",
+            ref ability => panic!("No icon for {:?}", ability),
         };
-        let text = Box::new(Text::new((text.as_str(), font, FONT_SIZE)));
+        let image = graphics::Image::new(context, image_path)?;
         let msg = Message::Ability(ability.ability.clone());
-        let button = ui::Button::new(context, text, h, gui.sender(), msg)?;
-        layout.add(Box::new(button));
+        let mut button = ui::Button::new(context, Box::new(image), h, gui.sender(), msg)?;
+        if !state::can_agent_use_ability(state, id, &ability.ability) {
+            button.set_active(false);
+        }
+        if let SelectionMode::Ability(selected_ability) = mode {
+            if selected_ability == &ability.ability {
+                button.set_color([0.0, 0.0, 0.9, 1.0].into());
+            }
+        }
+        if let ability::Status::Cooldown(n) = ability.status {
+            let mut layers = ui::LayersLayout::new();
+            layers.add(Box::new(button));
+            let text = Box::new(Text::new((format!(" ({})", n).as_str(), font, FONT_SIZE)));
+            let label = ui::Label::new(context, text, h / 2.0)?;
+            layers.add(Box::new(label));
+            layout.add(Box::new(layers));
+        } else {
+            layout.add(Box::new(button));
+        }
+        layout.add(Box::new(ui::Spacer::new_vertical(h / 8.0)));
     }
     let anchor = ui::Anchor(ui::HAnchor::Right, ui::VAnchor::Middle);
-    let layout = ui::pack(layout);
-    gui.add(&layout, anchor);
-    Ok(Some(layout))
+    let packed_layout = ui::pack(layout);
+    gui.add(&packed_layout, anchor);
+    Ok(Some(packed_layout))
 }
 
-fn make_gui(context: &mut Context, font: Font) -> ZResult<ui::Gui<Message>> {
+fn build_panel_end_turn(context: &mut Context, gui: &mut Gui<Message>) -> ZResult<ui::RcWidget> {
+    let h = line_heights().large;
+    let icon = Box::new(graphics::Image::new(context, "/icon_end_turn.png")?);
+    let button = ui::Button::new(context, icon, h, gui.sender(), Message::EndTurn)?;
+    let layout = ui::VLayout::from_widget(Box::new(button));
+    let anchor = ui::Anchor(ui::HAnchor::Right, ui::VAnchor::Bottom);
+    let packed_layout = ui::pack(layout);
+    gui.add(&packed_layout, anchor);
+    Ok(packed_layout)
+}
+
+fn build_panel_ability_description(
+    context: &mut Context,
+    font: Font,
+    gui: &mut Gui<Message>,
+    state: &State,
+    ability: &Ability,
+    id: Id,
+) -> ZResult<ui::RcWidget> {
+    let text = |s: &str| Box::new(Text::new((s, font, FONT_SIZE)));
+    let h = line_heights().normal;
+    let mut layout = ui::VLayout::new();
+    let text_title = text(&format!("<Ability '{}'>", ability.title()));
+    layout.add(Box::new(ui::Label::new(context, text_title, h)?));
+    for line in ability.extended_description() {
+        layout.add(Box::new(ui::Label::new(context, text(&line), h)?));
+    }
+    let agent_player_id = state.parts().belongs_to.get(id).0;
+    let abilities = &state.parts().abilities.get(id).0;
+    let r_ability = abilities.iter().find(|r| &r.ability == ability).unwrap();
+    let is_enemy_agent = agent_player_id != state.player_id();
+    let text_cooldown = text(&format!("Cooldown: {}", r_ability.base_cooldown));
+    layout.add(Box::new(ui::Label::new(context, text_cooldown, h)?));
+    if !state::can_agent_use_ability(state, id, ability) {
+        layout.add(Box::new(ui::Spacer::new_vertical(h / 2.0)));
+        let s = if is_enemy_agent {
+            "Can't be used: enemy agent.".into()
+        } else if let ability::Status::Cooldown(n) = r_ability.status {
+            format!("Can't be used: cooldown ({} turns).", n)
+        } else {
+            "Can't be used: no attacks or jokers.".into()
+        };
+        layout.add(Box::new(ui::Label::new(context, text(&s), h)?));
+    }
+    layout.add(Box::new(ui::Spacer::new_vertical(h / 2.0)));
+    let text_cancel = text("Click on an empty tile to cancel.");
+    layout.add(Box::new(ui::Label::new(context, text_cancel, h)?));
+    let anchor = ui::Anchor(ui::HAnchor::Right, ui::VAnchor::Bottom);
+    let layout = utils::wrap_widget_and_add_bg(context, Box::new(layout))?;
+    let packed_layout = ui::pack(layout);
+    gui.add(&packed_layout, anchor);
+    Ok(packed_layout)
+}
+
+fn make_gui(context: &mut Context) -> ZResult<ui::Gui<Message>> {
     let mut gui = ui::Gui::new(context);
-    let h = line_heights().big;
+    let h = line_heights().large;
     {
-        let text = Box::new(Text::new(("[deselect]", font, FONT_SIZE)));
-        let button = ui::Button::new(context, text, h, gui.sender(), Message::Deselect)?;
-        let mut layout = ui::VLayout::new();
-        layout.add(Box::new(button));
-        let anchor = ui::Anchor(ui::HAnchor::Right, ui::VAnchor::Top);
-        gui.add(&ui::pack(layout), anchor);
-    }
-    {
-        let text = Box::new(Text::new(("[end turn]", font, FONT_SIZE)));
-        let button = ui::Button::new(context, text, h, gui.sender(), Message::EndTurn)?;
-        let mut layout = ui::VLayout::new();
-        layout.add(Box::new(button));
-        let anchor = ui::Anchor(ui::HAnchor::Right, ui::VAnchor::Bottom);
-        gui.add(&ui::pack(layout), anchor);
-    }
-    {
-        let text = Box::new(Text::new(("[exit]", font, FONT_SIZE)));
-        let button = ui::Button::new(context, text, h, gui.sender(), Message::Exit)?;
-        let mut layout = ui::VLayout::new();
-        layout.add(Box::new(button));
+        let icon = Box::new(graphics::Image::new(context, "/icon_menu.png")?);
+        let button = ui::Button::new(context, icon, h, gui.sender(), Message::Exit)?;
+        let layout = ui::VLayout::from_widget(Box::new(button));
         let anchor = ui::Anchor(ui::HAnchor::Left, ui::VAnchor::Top);
         gui.add(&ui::pack(layout), anchor);
     }
@@ -212,6 +303,7 @@ pub struct Battle {
     font: graphics::Font,
     gui: Gui<Message>,
     state: State,
+    battle_type: scenario::BattleType,
     mode: SelectionMode,
     view: BattleView,
     selected_agent_id: Option<Id>,
@@ -220,18 +312,22 @@ pub struct Battle {
     ai: Ai,
     panel_info: Option<ui::RcWidget>,
     panel_abilities: Option<ui::RcWidget>,
-    sender: Sender<BattleResult>,
+    panel_ability_description: Option<ui::RcWidget>,
+    panel_end_turn: Option<ui::RcWidget>,
+    sender: Sender<Option<BattleResult>>,
+    confirmation_receiver_exit: Option<Receiver<screen::confirm::Message>>,
 }
 
 impl Battle {
     pub fn new(
         context: &mut Context,
         scenario: scenario::Scenario,
+        battle_type: scenario::BattleType,
         prototypes: Prototypes,
-        sender: Sender<BattleResult>,
+        sender: Sender<Option<BattleResult>>,
     ) -> ZResult<Self> {
         let font = default_font(context);
-        let gui = make_gui(context, font)?;
+        let mut gui = make_gui(context)?;
         let radius = scenario.map_radius;
         let mut view = BattleView::new(radius, context)?;
         let mut actions = Vec::new();
@@ -242,26 +338,29 @@ impl Battle {
         });
         actions.push(make_action_create_map(&state, context, &view)?);
         view.add_action(action::Sequence::new(actions).boxed());
+        let panel_end_turn = Some(build_panel_end_turn(context, &mut gui)?);
         Ok(Self {
             gui,
             font,
             view,
             mode: SelectionMode::Normal,
             state,
+            battle_type,
             selected_agent_id: None,
             pathfinder: Pathfinder::new(radius),
             block_timer: None,
             ai: Ai::new(PlayerId(1), radius),
             panel_info: None,
             panel_abilities: None,
+            panel_end_turn,
+            panel_ability_description: None,
             sender,
+            confirmation_receiver_exit: None,
         })
     }
 
     fn end_turn(&mut self, context: &mut Context) -> ZResult {
-        if self.block_timer.is_some() {
-            return Ok(());
-        }
+        utils::remove_widget(&mut self.gui, &mut self.panel_end_turn)?;
         self.deselect()?;
         let command = command::EndTurn.into();
         let mut actions = Vec::new();
@@ -287,20 +386,35 @@ impl Battle {
     }
 
     fn use_ability(&mut self, context: &mut Context, ability: Ability) -> ZResult {
-        // TODO: code duplication (see check.rs and event.rs)
-        let id = self.selected_agent_id.unwrap(); // TODO: Extract to some specific method
-        let agent_player_id = self.state.parts().belongs_to.get(id).0;
-        if agent_player_id != self.state.player_id() {
-            debug!("Can't command enemy agent");
-            return Ok(()); // TODO: fix error handling
-        }
-        for rechargeable in &self.state.parts().abilities.get(id).0 {
-            if rechargeable.ability == ability && rechargeable.status != ability::Status::Ready {
-                debug!("ability isn't ready yet");
-                return Ok(());
+        let id = self.selected_agent_id.unwrap();
+        if let SelectionMode::Ability(current_ability) = &self.mode {
+            if current_ability == &ability {
+                // Exit the ability mode if its icon was pressed again.
+                return self.set_mode(context, id, SelectionMode::Normal);
             }
         }
         self.set_mode(context, id, SelectionMode::Ability(ability))
+    }
+
+    fn popup_confirm_exit(&mut self, context: &mut Context) -> ZResult<Box<dyn Screen>> {
+        let (sender, receiver) = channel();
+        self.confirmation_receiver_exit = Some(receiver);
+        let message = match self.battle_type {
+            scenario::BattleType::Skirmish => "Abandon this battle?",
+            scenario::BattleType::CampaignNode => "Abandon the whole campaign?",
+        };
+        let popup = screen::Confirm::from_line(context, message, sender)?;
+        Ok(Box::new(popup))
+    }
+
+    fn popup_passive_ability_info(
+        &mut self,
+        context: &mut Context,
+        ability: PassiveAbility,
+    ) -> ZResult<Box<dyn Screen>> {
+        let ability = screen::ability_info::ActiveOrPassiveAbility::Passive(ability);
+        let popup = screen::AbilityInfo::new(context, ability)?;
+        Ok(Box::new(popup))
     }
 
     fn do_command_inner(
@@ -348,6 +462,7 @@ impl Battle {
     fn remove_selected_highlighted_tiles_and_widgets(&mut self) -> ZResult {
         utils::remove_widget(&mut self.gui, &mut self.panel_info)?;
         utils::remove_widget(&mut self.gui, &mut self.panel_abilities)?;
+        utils::remove_widget(&mut self.gui, &mut self.panel_ability_description)?;
         if self.selected_agent_id.is_some() {
             self.view.remove_highlights();
         }
@@ -367,17 +482,22 @@ impl Battle {
         let state = &self.state;
         let gui = &mut self.gui;
         match mode {
-            SelectionMode::Ability(_) => {
-                // TODO: Update the GUI here: explain how to use or cancel the ability.
-                // 'Select target tile'
+            SelectionMode::Ability(ref ability) => {
+                utils::remove_widget(gui, &mut self.panel_end_turn)?;
+                self.panel_ability_description = Some(build_panel_ability_description(
+                    context, self.font, gui, state, ability, id,
+                )?);
             }
             SelectionMode::Normal => {
                 self.pathfinder.fill_map(state, id);
-                self.panel_info = Some(build_panel_agent_info(context, self.font, gui, state, id)?);
-                self.panel_abilities =
-                    build_panel_agent_abilities(context, self.font, gui, state, id)?;
+                if self.panel_end_turn.is_none() {
+                    self.panel_end_turn = Some(build_panel_end_turn(context, gui)?);
+                }
             }
         }
+        self.panel_abilities =
+            build_panel_agent_abilities(context, &self.view, self.font, gui, state, id, &mode)?;
+        self.panel_info = Some(build_panel_agent_info(context, self.font, gui, state, id)?);
         let map = self.pathfinder.map();
         self.view.set_mode(state, context, map, id, &mode)?;
         self.mode = mode;
@@ -442,7 +562,7 @@ impl Battle {
         }
     }
 
-    fn handle_event_click(&mut self, context: &mut Context, point: Point2<f32>) -> ZResult {
+    fn handle_click(&mut self, context: &mut Context, point: Point2<f32>) -> ZResult {
         let pos = geom::point_to_hex(self.view.tile_size(), point);
         self.gui.click(point);
         if self.block_timer.is_some() {
@@ -481,21 +601,32 @@ impl Battle {
         }
         Ok(())
     }
+
+    fn send_battle_result(&self, result: Option<BattleResult>) {
+        let err_msg = "Can't report back a battle's result";
+        self.sender.send(result).expect(err_msg);
+    }
 }
 
 impl Screen for Battle {
-    fn update(&mut self, context: &mut Context, dtime: Duration) -> ZResult<Transition> {
+    fn update(&mut self, context: &mut Context, dtime: Duration) -> ZResult<StackCommand> {
+        if screen::confirm::try_receive_yes(&self.confirmation_receiver_exit) {
+            self.confirmation_receiver_exit = None;
+            self.send_battle_result(None);
+            return Ok(StackCommand::Pop);
+        }
         self.view.tick(dtime);
         self.update_block_timer(context, dtime)?;
         if self.block_timer.is_none() {
             if let Some(result) = self.state.battle_result().clone() {
-                self.sender
-                    .send(result)
-                    .expect("Can't report back a battle's result");
-                return Ok(Transition::Pop);
+                self.send_battle_result(Some(result));
+                return Ok(StackCommand::Pop);
+            }
+            if self.panel_end_turn.is_none() && self.mode == SelectionMode::Normal {
+                self.panel_end_turn = Some(build_panel_end_turn(context, &mut self.gui)?);
             }
         }
-        Ok(Transition::None)
+        Ok(StackCommand::None)
     }
 
     fn draw(&self, context: &mut Context) -> ZResult {
@@ -508,17 +639,25 @@ impl Screen for Battle {
         self.gui.resize(aspect_ratio);
     }
 
-    fn click(&mut self, context: &mut Context, pos: Point2<f32>) -> ZResult<Transition> {
+    fn click(&mut self, context: &mut Context, pos: Point2<f32>) -> ZResult<StackCommand> {
         let message = self.gui.click(pos);
         info!("Battle: click: pos={:?}, message={:?}", pos, message);
         match message {
-            Some(Message::Exit) => return Ok(Transition::Pop),
-            Some(Message::EndTurn) => self.end_turn(context)?,
-            Some(Message::Deselect) => self.deselect()?,
+            Some(Message::Exit) => {
+                return Ok(StackCommand::PushPopup(self.popup_confirm_exit(context)?));
+            }
+            Some(Message::EndTurn) => {
+                assert!(self.block_timer.is_none());
+                self.end_turn(context)?;
+            }
             Some(Message::Ability(ability)) => self.use_ability(context, ability)?,
-            None => self.handle_event_click(context, pos)?,
+            Some(Message::PassiveAbilityInfo(ability)) => {
+                let popup = self.popup_passive_ability_info(context, ability)?;
+                return Ok(StackCommand::PushPopup(popup));
+            }
+            None => self.handle_click(context, pos)?,
         }
-        Ok(Transition::None)
+        Ok(StackCommand::None)
     }
 
     fn move_mouse(&mut self, _context: &mut Context, point: Point2<f32>) -> ZResult {

--- a/src/screen/battle/visualize.rs
+++ b/src/screen/battle/visualize.rs
@@ -71,6 +71,7 @@ pub fn message(
     Ok(fork(seq(vec![fork(action_move), action_show_hide])))
 }
 
+// TODO: Add some bg? Text is not that readable atm.
 fn announce(
     view: &mut BattleView,
     context: &mut Context,
@@ -904,7 +905,7 @@ fn visualize_event_use_ability(
         _ => action::Empty::new().boxed(),
     };
     let pos = state.parts().pos.get(event.id).0;
-    let text = event.ability.to_string();
+    let text = event.ability.title();
     let mut actions = Vec::new();
     if let Some(facing) = geom::Facing::from_positions(view.tile_size(), pos, event.pos) {
         let sprite = view.id_to_sprite(event.id).clone();

--- a/src/screen/confirm.rs
+++ b/src/screen/confirm.rs
@@ -1,0 +1,125 @@
+use std::{
+    sync::mpsc::{Receiver, Sender},
+    time::Duration,
+};
+
+use ggez::{
+    graphics::{self, Text},
+    Context,
+};
+use nalgebra::Point2;
+use ui::{self, Gui, Widget};
+
+use crate::{
+    screen::{Screen, StackCommand},
+    utils, ZResult,
+};
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum Message {
+    Yes,
+    No,
+}
+
+//// A helper function for a receiving side.
+pub fn try_receive_yes(opt_rx: &Option<Receiver<Message>>) -> bool {
+    utils::try_receive(opt_rx) == Some(Message::Yes)
+}
+
+#[derive(Debug)]
+pub struct Confirm {
+    font: graphics::Font,
+    gui: Gui<Message>,
+    sender: Sender<Message>,
+}
+
+impl Confirm {
+    pub fn from_lines(
+        context: &mut Context,
+        lines: &[impl AsRef<str>],
+        sender: Sender<Message>,
+    ) -> ZResult<Self> {
+        let font = utils::default_font(context);
+        let h = utils::line_heights().big;
+        let font_size = utils::font_size();
+        let mut layout = ui::VLayout::new();
+        for line in lines {
+            let text = Box::new(Text::new((line.as_ref(), font, font_size)));
+            let label = Box::new(ui::Label::new(context, text, h)?);
+            layout.add(label);
+        }
+        Self::from_widget(context, Box::new(layout), sender)
+    }
+
+    pub fn from_line(context: &mut Context, line: &str, sender: Sender<Message>) -> ZResult<Self> {
+        Self::from_lines(context, &[line], sender)
+    }
+
+    pub fn from_widget(
+        context: &mut Context,
+        widget: Box<dyn ui::Widget>,
+        sender: Sender<Message>,
+    ) -> ZResult<Self> {
+        let font = utils::default_font(context);
+        let mut gui = ui::Gui::new(context);
+        let h = utils::line_heights().big;
+        let font_size = utils::font_size();
+        let mut layout = ui::VLayout::new();
+        let spacer = || Box::new(ui::Spacer::new_vertical(h * 0.5));
+        let mut add = |w| layout.add(w);
+        let button = |context: &mut Context, line, message| {
+            let text = Box::new(Text::new((line, font, font_size)));
+            ui::Button::new(context, text, h, gui.sender(), message)
+        };
+        let yes = button(context, "yes", Message::Yes)?;
+        let no = button(context, "no", Message::No)?;
+        let spacer_width = widget.rect().w - yes.rect().w - no.rect().w;
+        let mut line_layout = ui::HLayout::new();
+        line_layout.add(Box::new(yes));
+        line_layout.add(Box::new(ui::Spacer::new_horizontal(spacer_width)));
+        line_layout.add(Box::new(no));
+        add(widget);
+        add(spacer());
+        add(Box::new(line_layout));
+        let pack_offset = 0.04;
+        let layout = utils::pack_widget_into_offset_table(Box::new(layout), pack_offset);
+        let layout = utils::wrap_widget_and_add_bg(context, layout)?;
+        let anchor = ui::Anchor(ui::HAnchor::Middle, ui::VAnchor::Middle);
+        gui.add(&ui::pack(layout), anchor);
+        Ok(Self { font, gui, sender })
+    }
+}
+
+// TODO: handle Enter/ESC keys
+impl Screen for Confirm {
+    fn update(&mut self, _context: &mut Context, _dtime: Duration) -> ZResult<StackCommand> {
+        Ok(StackCommand::None)
+    }
+
+    fn draw(&self, context: &mut Context) -> ZResult {
+        self.gui.draw(context)?;
+        Ok(())
+    }
+
+    fn click(&mut self, _: &mut Context, pos: Point2<f32>) -> ZResult<StackCommand> {
+        let message = self.gui.click(pos);
+        match message {
+            Some(message) => {
+                self.sender
+                    .send(message)
+                    .expect("Can't report back the result");
+                Ok(StackCommand::Pop)
+            }
+            None => Ok(StackCommand::None),
+        }
+    }
+
+    fn resize(&mut self, aspect_ratio: f32) {
+        self.gui.resize(aspect_ratio);
+    }
+
+    fn move_mouse(&mut self, _context: &mut Context, pos: Point2<f32>) -> ZResult {
+        self.gui.move_mouse(pos);
+        Ok(())
+    }
+}

--- a/src/screen/main_menu.rs
+++ b/src/screen/main_menu.rs
@@ -13,8 +13,8 @@ use scene::Sprite;
 use ui::{self, Gui};
 
 use crate::{
-    core::battle::{component::Prototypes, state},
-    screen::{self, Screen, Transition},
+    core::battle::{component::Prototypes, scenario, state},
+    screen::{self, Screen, StackCommand},
     utils, ZResult,
 };
 
@@ -25,26 +25,25 @@ enum Message {
     StartCampaign,
 }
 
+// TODO: Is it possible to make buttons same width? See Qt's stretch factor.
 fn make_gui(context: &mut Context, font: Font) -> ZResult<ui::Gui<Message>> {
     let mut gui = ui::Gui::new(context);
     let h = utils::line_heights().large;
     let font_size = utils::font_size();
-    let button_battle = {
-        let text = Box::new(Text::new(("[demo battle]", font, font_size)));
-        ui::Button::new(context, text, h, gui.sender(), Message::StartInstant)?
-    };
-    let button_campaign = {
-        let text = Box::new(Text::new(("[campaign]", font, font_size)));
-        ui::Button::new(context, text, h, gui.sender(), Message::StartCampaign)?
-    };
-    let button_exit = {
-        let text = Box::new(Text::new(("[exit]", font, font_size)));
-        ui::Button::new(context, text, h, gui.sender(), Message::Exit)?
+    let space = || Box::new(ui::Spacer::new_vertical(h / 8.0));
+    let button = &mut |text, message| {
+        let text = Box::new(Text::new((text, font, font_size)));
+        ui::Button::new(context, text, h, gui.sender(), message).map(Box::new)
     };
     let mut layout = ui::VLayout::new();
-    layout.add(Box::new(button_battle));
-    layout.add(Box::new(button_campaign));
-    layout.add(Box::new(button_exit));
+    layout.add(button("demo battle", Message::StartInstant)?);
+    layout.add(space());
+    layout.add(button("campaign", Message::StartCampaign)?);
+    #[cfg(not(target_arch = "wasm32"))] // can't quit WASM
+    {
+        layout.add(space());
+        layout.add(button("exit", Message::Exit)?);
+    }
     let anchor = ui::Anchor(ui::HAnchor::Middle, ui::VAnchor::Middle);
     gui.add(&ui::pack(layout), anchor);
     Ok(gui)
@@ -53,30 +52,26 @@ fn make_gui(context: &mut Context, font: Font) -> ZResult<ui::Gui<Message>> {
 #[derive(Debug)]
 pub struct MainMenu {
     gui: Gui<Message>,
-
-    receiver: Option<Receiver<state::BattleResult>>,
+    receiver_battle_result: Option<Receiver<Option<state::BattleResult>>>,
 }
 
 impl MainMenu {
     pub fn new(context: &mut Context) -> ZResult<Self> {
         let font = utils::default_font(context);
         let gui = make_gui(context, font)?;
-
         let mut sprite = Sprite::from_path(context, "/tile.png", 0.1)?;
         sprite.set_centered(true);
         sprite.set_pos(Point2::new(0.5, 0.5));
-
-        // TODO: create some random agent arc-moving animation
         Ok(Self {
             gui,
-            receiver: None,
+            receiver_battle_result: None,
         })
     }
 }
 
 impl Screen for MainMenu {
-    fn update(&mut self, _context: &mut Context, _: Duration) -> ZResult<Transition> {
-        Ok(Transition::None)
+    fn update(&mut self, _context: &mut Context, _: Duration) -> ZResult<StackCommand> {
+        Ok(StackCommand::None)
     }
 
     fn draw(&self, context: &mut Context) -> ZResult {
@@ -88,24 +83,25 @@ impl Screen for MainMenu {
         self.gui.resize(aspect_ratio);
     }
 
-    fn click(&mut self, context: &mut Context, pos: Point2<f32>) -> ZResult<Transition> {
+    fn click(&mut self, context: &mut Context, pos: Point2<f32>) -> ZResult<StackCommand> {
         let message = self.gui.click(pos);
         debug!("MainMenu: click: pos={:?}, message={:?}", pos, message);
         match message {
             Some(Message::StartInstant) => {
                 let scenario = utils::deserialize_from_file(context, "/scenario_01.ron")?;
                 let (sender, receiver) = channel();
-                self.receiver = Some(receiver);
-                let prototypes = Prototypes::from_str(&utils::read_file(context, "/objects.ron")?);
-                let screen = screen::Battle::new(context, scenario, prototypes, sender)?;
-                Ok(Transition::Push(Box::new(screen)))
+                self.receiver_battle_result = Some(receiver);
+                let proto = Prototypes::from_str(&utils::read_file(context, "/objects.ron")?);
+                let battle_type = scenario::BattleType::Skirmish;
+                let screen = screen::Battle::new(context, scenario, battle_type, proto, sender)?;
+                Ok(StackCommand::PushScreen(Box::new(screen)))
             }
             Some(Message::StartCampaign) => {
                 let screen = screen::Campaign::new(context)?;
-                Ok(Transition::Push(Box::new(screen)))
+                Ok(StackCommand::PushScreen(Box::new(screen)))
             }
-            Some(Message::Exit) => Ok(Transition::Pop),
-            None => Ok(Transition::None),
+            Some(Message::Exit) => Ok(StackCommand::Pop),
+            None => Ok(StackCommand::None),
         }
     }
 


### PR DESCRIPTION
This ~~giant ugly blob of interconnected changes~~ PR:

- Replaces text with icons in the abilities menu and adds ability descriptions;
- Replaces "end turn", "menu" and "info" buttons with icons too;
- Removes the "deselect" button;
- Hides the "End Turn" button during enemy's turn;
- Adds a battle exit & campaign exit confirmation dialogs (and `enum BattleType { Skirmish, CampaignNode }` to distinguish them).
- Adds popup screens and renames `screen::Transition` to `screen::StackCommand`;
- Allows grouping related widgets into panels;
- Allows exiting from the ability mode by clicking on the ability icon again;
- Adds a black frame, an `is_active` property and custom color highlighting to `zgui::Button`;
- Adds new zgui widgets: `ColoredRect`, `LayersLayout`;
- ... aaand does a bunch of smaller tweaks and changes.

All icons: ![image](https://user-images.githubusercontent.com/662976/77236226-c83b0400-6bcd-11ea-9627-8dd6e2ee9e45.png)

Battle screenshot showing icon buttons, ability descriptions, agent info grouped into one panel:
![image](https://user-images.githubusercontent.com/662976/77235881-b6a42d00-6bca-11ea-8cba-c79b76943c0e.png)

Example of widgets grouping & grayed-out buttons in campaign menu: ![image](https://user-images.githubusercontent.com/662976/77236290-3bdd1100-6bce-11ea-89ab-fbe6bfaed49f.png)

Example of confirmation dialog: ![image](https://user-images.githubusercontent.com/662976/77236251-fa4c6600-6bcd-11ea-82f4-933191034d0f.png)

Depends on https://github.com/ozkriff/zemeroth_assets/pull/7

Closes #150 (_"Gray-out inactive buttons"_)
Closes #276 (_"Replace text with icons in abilities menu"_)
Closes #387 (_"The player shouldn't be able to restart a battle in a campaign"_)
Closes #560 (_"Exit confirmation dialogs"_)

