### PR TITLE
Add widget stretching & tweak game's UI accordingly

### DIFF
--- a/src/core/battle/ability.rs
+++ b/src/core/battle/ability.rs
@@ -215,7 +215,7 @@ impl PassiveAbility {
     pub fn extended_description(self) -> Vec<String> {
         match self {
             PassiveAbility::HeavyImpact => vec![
-                "Regular attack throws target one tile away.".into(),
+                "Regular attack throws the target one tile away.".into(),
                 format!(
                     "Works on targets with a weight for up to {}.",
                     Weight::Normal
@@ -231,7 +231,7 @@ impl PassiveAbility {
             PassiveAbility::SpikeTrap => {
                 vec!["Damages agents that enter into or begin their turn in the same tile.".into()]
             }
-            PassiveAbility::PoisonAttack => vec!["Regular attack poisons target.".into()],
+            PassiveAbility::PoisonAttack => vec!["Regular attack poisons the target.".into()],
             PassiveAbility::Regenerate(a) => vec![format!(
                 "Regenerates {} strength points every turn.",
                 (a.0).0

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -22,7 +22,7 @@ pub use self::{
 };
 
 const COLOR_SCREEN_BG: Color = Color::new(0.9, 0.9, 0.8, 1.0);
-const COLOR_POPUP_BG: Color = Color::new(0.9, 0.9, 0.8, 0.8);
+const COLOR_POPUP_BG: Color = Color::new(0.9, 0.9, 0.8, 0.9);
 
 #[derive(Debug)]
 pub enum StackCommand {

--- a/src/screen/battle/visualize.rs
+++ b/src/screen/battle/visualize.rs
@@ -28,6 +28,17 @@ use crate::{
     ZResult,
 };
 
+pub mod color {
+    use gwg::graphics::Color;
+
+    pub const STRENGTH: Color = Color::new(0.0, 0.7, 0.0, 1.0);
+    pub const DAMAGE: Color = Color::new(0.3, 0.5, 0.3, 0.5);
+    pub const ARMOR: Color = Color::new(1.0, 1.0, 0.5, 1.0);
+    pub const JOKERS: Color = Color::new(1.0, 1.0, 1.0, 1.0);
+    pub const ATTACKS: Color = Color::new(1.0, 0.0, 0.0, 1.0);
+    pub const MOVES: Color = Color::new(0.2, 0.2, 1.0, 1.0);
+}
+
 const BLOOD_SPRITE_DURATION_TURNS: i32 = 6; // TODO: i32 -> Turns, Rounds, etc
 const TIME_LUNGE_TO: f32 = 0.1;
 const TIME_LUNGE_FROM: f32 = 0.15;
@@ -437,13 +448,13 @@ fn generate_brief_obj_info(
     let base = point;
     let rows: &[&[_]] = &[
         &[
-            ([0.0, 0.7, 0.0, 1.0], strength.strength.0),
-            ([0.3, 0.5, 0.3, 0.5], damage),
-            ([1.0, 1.0, 0.0, 1.0], armor.0),
+            (color::STRENGTH, strength.strength.0),
+            (color::DAMAGE, damage),
+            (color::ARMOR, armor.0),
         ],
-        &[([1.0, 1.0, 1.0, 1.0], agent.jokers.0)],
-        &[([1.0, 0.0, 0.0, 1.0], agent.attacks.0)],
-        &[([0.0, 0.0, 1.0, 1.0], agent.moves.0)],
+        &[(color::JOKERS, agent.jokers.0)],
+        &[(color::ATTACKS, agent.attacks.0)],
+        &[(color::MOVES, agent.moves.0)],
     ];
     for &row in rows {
         for &(color, n) in row {

--- a/src/screen/battle/visualize.rs
+++ b/src/screen/battle/visualize.rs
@@ -457,7 +457,6 @@ fn generate_brief_obj_info(
     }
     let mut sprites = Vec::new();
     for &(color, point) in &dots {
-        let color = color.into();
         let mut sprite = Sprite::from_image(context, dot_image.clone(), size)?;
         sprite.set_centered(true);
         sprite.set_pos(point);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -68,18 +68,18 @@ pub fn line_heights() -> LineHeights {
     }
 }
 
-pub fn wrap_widget_and_add_bg(
-    context: &mut Context,
-    w: Box<dyn ui::Widget>,
-) -> ZResult<ui::LayersLayout> {
-    let bg = ui::ColoredRect::new(context, ui::SPRITE_COLOR_BG, w.rect())?;
+pub const OFFSET_SMALL: f32 = 0.02;
+pub const OFFSET_BIG: f32 = 0.04;
+
+pub fn add_bg(context: &mut Context, w: Box<dyn ui::Widget>) -> ZResult<ui::LayersLayout> {
+    let bg = ui::ColoredRect::new(context, ui::SPRITE_COLOR_BG, w.rect())?.stretchable(true);
     let mut layers = ui::LayersLayout::new();
     layers.add(Box::new(bg));
     layers.add(w);
     Ok(layers)
 }
 
-pub fn pack_widget_into_offset_table(w: Box<dyn ui::Widget>, offset: f32) -> Box<dyn ui::Widget> {
+pub fn add_offsets(w: Box<dyn ui::Widget>, offset: f32) -> Box<dyn ui::Widget> {
     let spacer = || {
         ui::Spacer::new(Rect {
             w: offset,
@@ -87,15 +87,30 @@ pub fn pack_widget_into_offset_table(w: Box<dyn ui::Widget>, offset: f32) -> Box
             ..Default::default()
         })
     };
-    let mut layout_h = ui::HLayout::new();
+    let mut layout_h = ui::HLayout::new().stretchable(true);
     layout_h.add(Box::new(spacer()));
     layout_h.add(w);
     layout_h.add(Box::new(spacer()));
-    let mut layout_v = ui::VLayout::new();
+    let mut layout_v = ui::VLayout::new().stretchable(true);
     layout_v.add(Box::new(spacer()));
     layout_v.add(Box::new(layout_h));
     layout_v.add(Box::new(spacer()));
     Box::new(layout_v)
+}
+
+pub fn add_offsets_and_bg(
+    context: &mut Context,
+    w: Box<dyn ui::Widget>,
+    offset: f32,
+) -> ZResult<ui::LayersLayout> {
+    add_bg(context, add_offsets(w, offset))
+}
+
+pub fn add_offsets_and_bg_big(
+    context: &mut Context,
+    w: Box<dyn ui::Widget>,
+) -> ZResult<ui::LayersLayout> {
+    add_offsets_and_bg(context, w, OFFSET_BIG)
 }
 
 pub fn remove_widget<M: Clone>(gui: &mut ui::Gui<M>, widget: &mut Option<ui::RcWidget>) -> ZResult {


### PR DESCRIPTION
This PR:

- Adds horizontal widget stretching to `zgui`. The new `can_stretch`, `stretch`, and `stretch_to_self` methods of the `zgui::Widget` trait are implemented for most of the widgets.
- Adds a `with_color` chain method to `zgui::Label`.
- Adds `utils::add_offsets_and_bg` helper function.
- Modifies the agent info panel:
  - adds colored dots (adds explicit color constants to do this),
  - aligns the values to the right using stretchable spacer widgets,
  - changes title style to `~~~`.
- Refactors the math behind `Button`'s geometry.
- Stretches the buttons in the main menu screen to the same width.
- Changes the layout of the `campaign` menu screen a little and decreases its main font size to normal.
- Changes the layout of the `agent_info` and `ability_info` popups. Increases the width of the "back" button to one-third of the window.
- Changes the layout of the `confirm` popup: stretches the "yes" and "no" buttons to one-third of the window.
- Makes popup bg less transparent.
- Adds constants for agent info dots' colors.
- Fixes some abilities extended descriptions.

![image](https://user-images.githubusercontent.com/662976/90262802-6cf8ff00-de57-11ea-991a-266ec48dc76f.png)

![image](https://user-images.githubusercontent.com/662976/90263570-82baf400-de58-11ea-8a53-e29c7462862b.png)

Closes #582 (_"Similary-Sized Buttons in Main Menu"_)
Closes #584 (_"Align info buttons in the campaign menu and the abilities panel"_)
Closes #585 (_"Add colored dots to the corresponding lines of the agent info panel"_)
