### PR TITLE
Add yield_now to mainloop

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,10 @@ impl event::EventHandler for MainState {
 
     fn draw(&mut self, context: &mut Context) -> GameResult {
         self.screens.draw(context).expect("Draw call failed");
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            std::thread::yield_now();
+        }
         Ok(())
     }
 


### PR DESCRIPTION
This can (combined with vsync) should be enough to stop the game from consuming all the CPU cycles.

Closes #587 (_"Add thread::sleep to main loop"_)