### PR TITLE
Optimize ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,30 +3,8 @@ name: CI
 on: [pull_request, push]
 
 jobs:
-  format:
-    name: Rustfmt
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Install rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          components: rustfmt
-          profile: minimal
-          override: true
-
-      - name: Run rustfmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
-
-  clippy:
-    name: Clippy
+  lints:
+    name: Lints
     runs-on: ubuntu-latest
 
     steps:
@@ -34,22 +12,19 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install packages
-        run: |
-          sudo apt-get -yq --no-install-suggests --no-install-recommends install libx11-dev libxi-dev libgl1-mesa-dev
+        run: sudo apt -yq --no-install-suggests --no-install-recommends install libx11-dev libxi-dev libgl1-mesa-dev
 
       - name: Install rust
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-          components: clippy
+          components: clippy, rustfmt
           profile: minimal
           override: true
 
-      - name: Run clippy
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: -- -D warnings
+      - run: cargo fmt --all -- --check
+
+      - run: cargo clippy -- -D warnings
 
   build:
     name: ${{ matrix.build }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,16 +55,13 @@ jobs:
     name: ${{ matrix.build }}
     runs-on: ${{ matrix.os }}
 
-    # The build matrix does not yet support 'allow failures' at job level.
-    # See `jobs.nightly` for the nightly job definition.
     strategy:
       matrix:
-        build: [Linux, macOS, Win32, Win64]
+        build: [Linux, macOS, Win32, Win64, Linux-beta]
 
         include:
           - build: Linux
             os: ubuntu-latest
-            packages: libx11-dev libxi-dev libgl1-mesa-dev
           - build: macOS
             os: macOS-latest
           - build: Win32
@@ -73,6 +70,9 @@ jobs:
             target: i686-pc-windows-msvc
           - build: Win64
             os: windows-latest
+          - build: Linux-beta
+            os: ubuntu-latest
+            rust: beta
 
     steps:
       - name: Checkout
@@ -97,9 +97,9 @@ jobs:
           override: true
 
       - name: Install packages (Linux)
-        if: runner.os == 'Linux' && matrix.packages
+        if: runner.os == 'Linux'
         run: |
-          sudo apt-get -yq --no-install-suggests --no-install-recommends install ${{ matrix.packages }}
+          sudo apt-get -yq --no-install-suggests --no-install-recommends install libx11-dev libxi-dev libgl1-mesa-dev
 
       - name: Install resvg
         shell: bash
@@ -149,47 +149,4 @@ jobs:
           override: true
 
       - name: Build
-        run: |
-          ./utils/wasm/build.sh
-
-  nightly:
-    name: Nightly
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
-
-        include:
-          - os: ubuntu-latest
-            packages: libx11-dev libxi-dev libgl1-mesa-dev
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Install packages (Linux)
-        if: runner.os == 'Linux' && matrix.packages
-        run: |
-          sudo apt-get -yq --no-install-suggests --no-install-recommends install ${{ matrix.packages }}
-
-      - name: Install rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          profile: minimal
-          override: true
-
-      - name: Build
-        continue-on-error: true
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --examples --all
-
-      - name: Test
-        continue-on-error: true
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all
+        run: ./utils/wasm/build.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,17 +105,12 @@ jobs:
         shell: bash
         run: |
           if ! command -v resvg &> /dev/null; then
-            if [ "$RUNNER_OS" == "Linux" ]; then
-              cargo install resvg
-            elif [ "$RUNNER_OS" == "macOS" ]; then
-              cargo install resvg
-            elif [ "$RUNNER_OS" == "Windows" ]; then
+            if [ "$RUNNER_OS" == "Windows" ]; then
               curl -sL https://github.com/RazrFalcon/resvg/releases/download/v0.11.0/viewsvg-win.zip -O
               7z x viewsvg-win.zip
               mv resvg ~/.cargo/bin
             else
-              echo "$RUNNER_OS not supported"
-              exit 1
+              cargo install resvg
             fi
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,17 +104,19 @@ jobs:
       - name: Install resvg
         shell: bash
         run: |
-          if [ "$RUNNER_OS" == "Linux" ]; then
-            cargo install resvg
-          elif [ "$RUNNER_OS" == "macOS" ]; then
-            cargo install resvg
-          elif [ "$RUNNER_OS" == "Windows" ]; then
-            curl -sL https://github.com/RazrFalcon/resvg/releases/download/v0.11.0/viewsvg-win.zip -O
-            7z x viewsvg-win.zip
-            mv resvg ~/.cargo/bin
-          else
-            echo "$RUNNER_OS not supported"
-            exit 1
+          if ! command -v resvg &> /dev/null; then
+            if [ "$RUNNER_OS" == "Linux" ]; then
+              cargo install resvg
+            elif [ "$RUNNER_OS" == "macOS" ]; then
+              cargo install resvg
+            elif [ "$RUNNER_OS" == "Windows" ]; then
+              curl -sL https://github.com/RazrFalcon/resvg/releases/download/v0.11.0/viewsvg-win.zip -O
+              7z x viewsvg-win.zip
+              mv resvg ~/.cargo/bin
+            else
+              echo "$RUNNER_OS not supported"
+              exit 1
+            fi
           fi
 
       - name: Export assets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ~/.cargo/bin/resvg
+            target
+          key: ${{ runner.os }}-${{ matrix.build }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Install rust
         uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
This PR:
- Adds caching for `~/.cargo/registry`, `~/.cargo/git`, `~/.cargo/bin/resvg`, `target`
- Merges `Rustfmt` and `Clippy` jobs into `Lints`
- Removes nightly job - they're hard to cache, take too much time, and not that much important
- Adds Linux-beta to the general build matrix

The full CI check time should be ~4m now

Closes #609 (_"GA: Try adding cache"_)