### PR TITLE
atlas.svg: Rearranged spike_trap's spikes

### DIFF
--- a/assets_src/atlas.svg
+++ b/assets_src/atlas.svg
@@ -2210,56 +2210,56 @@
          sodipodi:nodetypes="cccccc"
          inkscape:connector-curvature="0"
          id="path238-5"
-         d="m 676.53808,475.67682 -1.02683,40.55493 6.67438,0.1913 -1.36911,-38.64196 -2.39592,-12.62558 z"
-         style="fill:#666666;fill-opacity:1;stroke:none;stroke-width:0.84711981px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+         d="m 678.67316,472.61062 -4.75442,39.99249 6.59692,1.48244 2.20369,-38.56076 -1.2111,-12.97651 z"
+         style="fill:#666666;fill-opacity:1;stroke:none;stroke-width:0.84712px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
       <path
          sodipodi:nodetypes="cccccc"
          inkscape:connector-curvature="0"
          id="path238-5-2"
-         d="m 698.65507,499.9263 -6.88737,39.83402 6.55861,1.39667 4.24597,-38.3799 -0.53559,-12.89261 z"
-         style="display:inline;fill:#666666;fill-opacity:1;stroke:none;stroke-width:0.84711981px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+         d="m 700.35406,490.68614 -6.88737,39.83402 6.55861,1.39667 4.24597,-38.3799 -0.53559,-12.89261 z"
+         style="display:inline;fill:#666666;fill-opacity:1;stroke:none;stroke-width:0.84712px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
       <path
          sodipodi:nodetypes="cccccc"
          inkscape:connector-curvature="0"
          id="path238-5-2-7"
-         d="m 630.70237,493.16057 7.46283,39.7043 6.53025,-1.55389 -9.39359,-37.21951 -4.96404,-11.65283 z"
-         style="display:inline;fill:#666666;fill-opacity:1;stroke:none;stroke-width:0.84711981px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+         d="m 627.57093,485.19099 7.46283,39.7043 6.53025,-1.55389 -9.39359,-37.21951 -4.96404,-11.65283 z"
+         style="display:inline;fill:#666666;fill-opacity:1;stroke:none;stroke-width:0.84712px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
       <path
          sodipodi:nodetypes="cccccc"
          inkscape:connector-curvature="0"
          id="path238-5-0"
-         d="m 646.69852,545.51497 1.57568,40.53291 6.66948,-0.3438 -3.84282,-38.43295 -3.19915,-12.4012 z"
-         style="display:inline;fill:#666666;fill-opacity:1;stroke:none;stroke-width:0.84711981px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+         d="m 637.73343,535.29109 1.57568,40.53291 6.66948,-0.3438 -3.84282,-38.43295 -3.19915,-12.4012 z"
+         style="display:inline;fill:#666666;fill-opacity:1;stroke:none;stroke-width:0.84712px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
       <path
          sodipodi:nodetypes="cccccc"
          inkscape:connector-curvature="0"
          id="path238-5-0-9"
-         d="m 682.61471,532.11846 -5.41462,40.11717 6.60449,1.09372 2.82899,-38.54274 -1.00991,-12.85704 z"
-         style="display:inline;fill:#666666;fill-opacity:1;stroke:none;stroke-width:0.84711981px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+         d="m 683.06515,535.86878 -5.41462,40.11717 6.60449,1.09372 2.82899,-38.54274 -1.00991,-12.85704 z"
+         style="display:inline;fill:#666666;fill-opacity:1;stroke:none;stroke-width:0.84712px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
       <path
          sodipodi:nodetypes="cccccc"
          inkscape:connector-curvature="0"
          id="path238-5-0-9-3"
-         d="m 660.47808,521.94574 2.49999,40.47482 6.65947,-0.53383 -4.71849,-38.3109 -3.48106,-12.30596 z"
-         style="display:inline;fill:#666666;fill-opacity:1;stroke:none;stroke-width:0.84711981px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+         d="m 659.41866,558.47467 0.49999,31.77533 6.65947,-0.53383 -2.71849,-29.61141 -3.48106,-12.30596 z"
+         style="display:inline;fill:#666666;fill-opacity:1;stroke:none;stroke-width:0.84712px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
       <path
          sodipodi:nodetypes="cccccc"
          inkscape:connector-curvature="0"
          id="path238-5-0-9-3-6"
-         d="m 650.43479,478.47481 0.43975,40.56818 6.67585,-0.11025 -2.76461,-38.54858 -2.85028,-12.50706 z"
-         style="display:inline;fill:#666666;fill-opacity:1;stroke:none;stroke-width:0.84711981px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+         d="m 651.50306,469.93671 0.43975,40.56818 6.67585,-0.11025 -2.76461,-38.54858 -2.85028,-12.50706 z"
+         style="display:inline;fill:#666666;fill-opacity:1;stroke:none;stroke-width:0.84712px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
       <path
          sodipodi:nodetypes="cccccc"
          inkscape:connector-curvature="0"
          id="path238-5-0-9-3-6-0"
-         d="m 617.25911,523.58976 9.69649,39.09659 6.42916,-2.01288 -11.48266,-36.48013 -5.61403,-11.27818 z"
-         style="display:inline;fill:#666666;fill-opacity:1;stroke:none;stroke-width:0.84711981px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+         d="m 618.68823,518.35564 9.69649,39.09659 6.42916,-2.01288 -11.48266,-36.48013 -5.61403,-11.27818 z"
+         style="display:inline;fill:#666666;fill-opacity:1;stroke:none;stroke-width:0.84712px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
       <path
          sodipodi:nodetypes="cccccc"
          inkscape:connector-curvature="0"
          id="path238-5-0-9-3-6-6"
-         d="m 706.2772,520.7006 -4.92449,40.196 6.61723,0.99292 2.35831,-38.58231 -1.16673,-12.84042 z"
-         style="display:inline;fill:#666666;fill-opacity:1;stroke:none;stroke-width:0.84711981px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+         d="m 704.0925,523.26036 -9.26594,38.55133 6.42441,2.50444 6.55555,-37.54919 0.25491,-12.9461 z"
+         style="display:inline;fill:#666666;fill-opacity:1;stroke:none;stroke-width:0.84712px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
     <g
        style="display:inline;stroke:none"


### PR DESCRIPTION
Now after I thought about it for a while it seems better to just edit the spikes' sprite so it well looks less weird with a bomb above it.

Closes #620 (_"Forbid throwing bombs to tiles with pikes"_)