### PR TITLE
Dynamic z-sort

### DIFF
--- a/assets/sprites.ron
+++ b/assets/sprites.ron
@@ -183,6 +183,7 @@
         offset_x: 0.0,
         offset_y: 0.2,
         shadow_size_coefficient: 0.001,
+        sub_tile_z: 0.1,
     ),
     "poison_cloud": (
         paths: {
@@ -191,6 +192,7 @@
         offset_x: 0.0,
         offset_y: 0.2,
         shadow_size_coefficient: 2.0,
+        sub_tile_z: 0.2,
     ),
     "spike_trap": (
         paths: {
@@ -199,5 +201,6 @@
         offset_x: 0.0,
         offset_y: 0.5,
         shadow_size_coefficient: 1.4,
+        sub_tile_z: -0.1,
     ),
 }

--- a/src/sprite_info.rs
+++ b/src/sprite_info.rs
@@ -8,4 +8,11 @@ pub struct SpriteInfo {
     pub offset_x: f32,
     pub offset_y: f32,
     pub shadow_size_coefficient: f32,
+
+    #[serde(default = "default_sub_tile_z")]
+    pub sub_tile_z: f32,
+}
+
+fn default_sub_tile_z() -> f32 {
+    0.0
 }

--- a/zscene/src/action.rs
+++ b/zscene/src/action.rs
@@ -1,12 +1,13 @@
 use std::{fmt::Debug, time::Duration};
 
 pub use crate::action::{
-    change_color_to::ChangeColorTo, empty::Empty, fork::Fork, hide::Hide, move_by::MoveBy,
-    sequence::Sequence, set_color::SetColor, set_facing::SetFacing, set_frame::SetFrame,
-    show::Show, sleep::Sleep,
+    change_color_to::ChangeColorTo, custom::Custom, empty::Empty, fork::Fork, hide::Hide,
+    move_by::MoveBy, sequence::Sequence, set_color::SetColor, set_facing::SetFacing,
+    set_frame::SetFrame, show::Show, sleep::Sleep,
 };
 
 mod change_color_to;
+mod custom;
 mod empty;
 mod fork;
 mod hide;

--- a/zscene/src/action/custom.rs
+++ b/zscene/src/action/custom.rs
@@ -1,0 +1,25 @@
+use std::fmt;
+
+use crate::Action;
+
+pub struct Custom {
+    f: Box<dyn FnMut()>,
+}
+
+impl fmt::Debug for Custom {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Custom").field("f", &"").finish()
+    }
+}
+
+impl Custom {
+    pub fn new(f: Box<dyn FnMut()>) -> Self {
+        Self { f }
+    }
+}
+
+impl Action for Custom {
+    fn begin(&mut self) {
+        (self.f)();
+    }
+}

--- a/zscene/src/action/show.rs
+++ b/zscene/src/action/show.rs
@@ -18,7 +18,6 @@ impl Show {
 impl Action for Show {
     fn begin(&mut self) {
         assert!(!self.layer.has_sprite(&self.sprite)); // TODO: add unit test for this
-        let mut data = self.layer.data.borrow_mut();
-        data.sprites.push(self.sprite.clone());
+        self.layer.add(&self.sprite);
     }
 }


### PR DESCRIPTION
This PR:
- Adds `zscene::action::Custom` for executing custom closures during the animations.
- Adds `z: f32` to sprites stored inside of `zscene::Layer`s and sorts them accordingly.
- Assigns `z` to object sprites based on their vertical tile position and `SpriteInfo::sub_tile_z`.
- Adds `set_z` calls to all event/effects visualizers that are related to changing positions.

Closes #319 (_"Z-sort sprites vertically"_)