### PR TITLE
Stop using mq::prelude

### DIFF
--- a/src/geom.rs
+++ b/src/geom.rs
@@ -1,4 +1,4 @@
-use mq::prelude::Vec2;
+use mq::math::glam::Vec2;
 
 use crate::core::{
     map::{hex_round, PosHex},

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ async fn main() {
         std::env::set_var("RUST_BACKTRACE", "1");
     }
     env_logger::init();
-    quad_rand::srand(mq::prelude::miniquad::date::now() as _);
+    quad_rand::srand(mq::miniquad::date::now() as _);
     assets::load().await;
     let mut state = MainState::new().expect("Can't create the main state");
     loop {

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -1,7 +1,10 @@
 use std::{fmt::Debug, time::Duration};
 
 use log::info;
-use mq::prelude::{Color, Rect, Vec2};
+use mq::{
+    color::Color,
+    math::{glam::Vec2, Rect},
+};
 
 use crate::{utils, ZResult};
 

--- a/src/screen/agent_info.rs
+++ b/src/screen/agent_info.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use heck::TitleCase;
-use mq::prelude::{Color, Vec2};
+use mq::{color::Color, math::glam::Vec2};
 use ui::{self, Drawable, Gui, Widget};
 
 use crate::{

--- a/src/screen/battle.rs
+++ b/src/screen/battle.rs
@@ -5,7 +5,7 @@ use std::{
 
 use heck::TitleCase;
 use log::{info, trace};
-use mq::prelude::{Color, Vec2};
+use mq::{color::Color, math::glam::Vec2};
 
 use ui::{self, Gui, Widget};
 use zscene::{action, Action, Boxed};

--- a/src/screen/battle/view.rs
+++ b/src/screen/battle/view.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, default::Default, time::Duration};
 
-use mq::prelude::{Color, Vec2};
+use mq::{color::Color, math::glam::Vec2};
 
 use zscene::{action, Action, Boxed, Layer, Scene, Sprite};
 

--- a/src/screen/battle/visualize.rs
+++ b/src/screen/battle/visualize.rs
@@ -2,7 +2,8 @@ use std::time::Duration;
 
 use log::{info, trace};
 use mq::{
-    prelude::{Color, Mat2, Vec2},
+    color::Color,
+    math::glam::{Mat2, Vec2},
     texture::Texture2D,
 };
 use zscene::{action, Action, Boxed, Facing, Sprite};
@@ -28,7 +29,7 @@ use crate::{
 };
 
 pub mod color {
-    use mq::prelude::Color;
+    use mq::color::Color;
 
     pub const STRENGTH: Color = Color::new(0.0, 0.7, 0.0, 1.0);
     pub const DAMAGE: Color = Color::new(0.3, 0.5, 0.3, 0.5);

--- a/src/screen/campaign.rs
+++ b/src/screen/campaign.rs
@@ -5,7 +5,7 @@ use std::{
 
 use heck::TitleCase;
 use log::info;
-use mq::{prelude::Vec2, text::Font};
+use mq::{math::glam::Vec2, text::Font};
 use ui::{self, Drawable, Gui, Widget};
 
 use crate::{

--- a/src/screen/confirm.rs
+++ b/src/screen/confirm.rs
@@ -3,7 +3,7 @@ use std::{
     time::Duration,
 };
 
-use mq::prelude::Vec2;
+use mq::math::glam::Vec2;
 use ui::{self, Gui, Widget};
 
 use crate::{

--- a/src/screen/general_info.rs
+++ b/src/screen/general_info.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use mq::prelude::Vec2;
+use mq::math::glam::Vec2;
 use ui::{self, Gui, Widget};
 
 use crate::{

--- a/src/screen/main_menu.rs
+++ b/src/screen/main_menu.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use log::trace;
-use mq::prelude::Vec2;
+use mq::math::glam::Vec2;
 use ui::{self, Gui, Widget};
 
 use crate::{

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,7 +2,7 @@ use std::{sync::mpsc::Receiver, time::Duration};
 
 use mq::{
     camera::{set_camera, Camera2D},
-    prelude::{Rect, Vec2},
+    math::{glam::Vec2, Rect},
 };
 
 use crate::ZResult;

--- a/zgui/examples/absolute_coordinates.rs
+++ b/zgui/examples/absolute_coordinates.rs
@@ -1,4 +1,4 @@
-use mq::prelude::{RED, WHITE};
+use mq::color::{RED, WHITE};
 use zgui as ui;
 
 mod common;

--- a/zgui/examples/common/mod.rs
+++ b/zgui/examples/common/mod.rs
@@ -2,7 +2,7 @@
 
 use mq::{
     camera::{set_camera, Camera2D},
-    prelude::{Rect, Vec2},
+    math::{glam::Vec2, Rect},
     text::{load_ttf_font, Font},
     texture::{self, Texture2D},
 };

--- a/zgui/examples/layers_layout.rs
+++ b/zgui/examples/layers_layout.rs
@@ -1,4 +1,4 @@
-use mq::prelude::WHITE;
+use mq::color::WHITE;
 use zgui as ui;
 
 mod common;

--- a/zgui/examples/nested.rs
+++ b/zgui/examples/nested.rs
@@ -1,4 +1,4 @@
-use mq::prelude::WHITE;
+use mq::color::WHITE;
 use zgui as ui;
 
 mod common;

--- a/zgui/examples/pixel_coordinates.rs
+++ b/zgui/examples/pixel_coordinates.rs
@@ -1,6 +1,7 @@
 use mq::{
     camera::{set_camera, Camera2D},
-    prelude::{Rect, RED, WHITE},
+    color::{RED, WHITE},
+    math::Rect,
 };
 use zgui as ui;
 

--- a/zgui/examples/remove.rs
+++ b/zgui/examples/remove.rs
@@ -1,4 +1,4 @@
-use mq::prelude::WHITE;
+use mq::color::WHITE;
 use zgui as ui;
 
 mod common;

--- a/zgui/examples/text_button.rs
+++ b/zgui/examples/text_button.rs
@@ -1,4 +1,4 @@
-use mq::prelude::WHITE;
+use mq::color::WHITE;
 use zgui as ui;
 
 mod common;

--- a/zgui/src/lib.rs
+++ b/zgui/src/lib.rs
@@ -11,7 +11,8 @@ use std::{
 use log::{info, trace};
 use mq::{
     camera::{set_camera, Camera2D},
-    prelude::{Color, Rect, Vec2},
+    color::Color,
+    math::{glam::Vec2, Rect},
     shapes,
     text::{draw_text_ex, measure_text, Font, TextParams},
     texture::{draw_texture_ex, DrawTextureParams, Texture2D},

--- a/zscene/examples/action.rs
+++ b/zscene/examples/action.rs
@@ -2,7 +2,8 @@ use std::time::Duration;
 
 use mq::{
     camera::{set_camera, Camera2D},
-    prelude::{Color, Rect, Vec2, BLACK},
+    color::{Color, BLACK},
+    math::{glam::Vec2, Rect},
     text,
     texture::{self, Texture2D},
     time, window,

--- a/zscene/src/action/change_color_to.rs
+++ b/zscene/src/action/change_color_to.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use mq::prelude::Color;
+use mq::color::Color;
 
 use crate::{Action, Sprite};
 

--- a/zscene/src/action/move_by.rs
+++ b/zscene/src/action/move_by.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use mq::prelude::Vec2;
+use mq::math::glam::Vec2;
 
 use crate::{Action, Sprite};
 

--- a/zscene/src/action/set_color.rs
+++ b/zscene/src/action/set_color.rs
@@ -1,4 +1,4 @@
-use mq::prelude::Color;
+use mq::color::Color;
 
 use crate::{Action, Sprite};
 

--- a/zscene/src/sprite.rs
+++ b/zscene/src/sprite.rs
@@ -1,7 +1,8 @@
 use std::{cell::RefCell, collections::HashMap, rc::Rc};
 
 use mq::{
-    prelude::{Color, Rect, Vec2},
+    color::Color,
+    math::{glam::Vec2, Rect},
     text::{self, Font},
     texture::{self, DrawTextureParams, Texture2D},
 };


### PR DESCRIPTION
See https://github.com/not-fl3/macroquad/pull/70 (_"Make a few types/mods reachable without prelude"_)

Part of #564 (_"Migrate to macroquad"_)