### PR TITLE
Remove allow(clippy::unnecessary_wraps)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::unnecessary_wraps)]
 #![windows_subsystem = "windows"]
 
 use std::time::Duration;


### PR DESCRIPTION
This lint is disabled by default in modern clippy