### PR TITLE
show message at agent pos on out of board action

### DIFF
--- a/src/screen/battle.rs
+++ b/src/screen/battle.rs
@@ -609,6 +609,12 @@ impl Battle {
             if check(&self.state, &command).is_ok() {
                 self.do_command(&command);
             } else {
+                let pos = if self.state.map().is_inboard(pos) {
+                    pos
+                } else {
+                    // on outboard click show message on agent pos
+                    self.state.parts().pos.get(id).0
+                };
                 self.view.message(pos, "cancelled")?;
             }
             self.set_mode(id, SelectionMode::Normal)?;


### PR DESCRIPTION
Hi!
This PR fixed panic by `assert!(self.is_inboard(pos));`

Case:
 - demo battle
 - choose alchemist
 - choose healing
 - click out side of map
 
 Solution: on out of board click - show `cancelled` message at agent pos
 
 Sorry for my poor English