### PR TITLE
campaign_01.ron: Fix typo in 5th scenario

### DIFF
--- a/assets/campaign_01.ron
+++ b/assets/campaign_01.ron
@@ -86,7 +86,7 @@ Plan(
         (
             scenario: (
                 rocky_tiles_count: 5,
-                randomied_objects: [
+                randomized_objects: [
                     (owner: None, typename: "boulder", line: None, count: 2),
                     (owner: None, typename: "spike_trap", line: None, count: 2),
                     (owner: Some((1)), typename: "imp", line: Some(Front), count: 6),


### PR DESCRIPTION
It's sad that serde doesn't catch unknown fields by default.
Should I slap `#[serde(deny_unknown_fields)]` on all my structs? :thinking: 